### PR TITLE
Pin myst-nb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup_args = dict(
         'nbformat',
         'nbconvert',
         'jupyter_client',
-        'myst-nb >=0.17',
+        'myst-nb >=0.17,<1',
         'sphinx-design',
         'notebook',
         'sphinx',


### PR DESCRIPTION
I'm starting to see our docs build failing, and I think the reason is the new myst-nb release. 

HoloViews:
![image](https://github.com/holoviz-dev/nbsite/assets/19758978/6f59ee97-7e35-48bd-8515-5664a8c7c37f)

Panel:
![image](https://github.com/holoviz-dev/nbsite/assets/19758978/e23637bf-cb66-4b83-b745-0768fc3631ca)
