### PR TITLE
Fix links from notebooks to notebooks when target notebook is not in the same directory (notebook directive)

### DIFF
--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -227,7 +227,7 @@ class FixNotebookLinks(Preprocessor):
         ] 
 
         """
-        for match in re.finditer(r"(\[.+\]\((.+\.ipynb)\))", markdown_text):
+        for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)\))", markdown_text):
             yield match.groups()
 
     def __call__(self, nb, resources):

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -196,35 +196,35 @@ class FixNotebookLinks(Preprocessor):
 
         cell['source'] = self.replace_notebook_links(
             markdown_text=cell['source'],
-            nb_dir=self.nb_path
+            rootdir=self.nb_path
         )
 
         return cell, resources
 
     @classmethod
-    def replace_notebook_links(cls, markdown_text: str, nb_dir:str):
+    def replace_notebook_links(cls, markdown_text: str, rootdir:str):
         """Replaces notebook links in a markdown text.
 
         Parameters
         ----------
         markdown_text: str
             Markdown text from a notebook markdown cell.
-        nb_dir:
-            The absolute path to the directory where the notebook is located
-            at, withuot a trailing slash.
+        rootdir:
+            The absolute path to the directory where the notebook that is being
+            processed (which contains links) is located at, without a trailing
+            slash.
         """
-        for nb_link, nb_filepath in cls._extract_links(markdown_text):
-            for source_filepath in cls._iter_source_file_candidates(nb_filepath):
-                markdown_text = cls.replace_notebook_link(markdown_text, nb_dir, source_filepath, nb_link)
+        for nb_link, target_nb_filepath in cls._extract_links(markdown_text):
+            for target_source_filepath in cls._iter_source_file_candidates(target_nb_filepath):
+                markdown_text = cls.replace_notebook_link(markdown_text, rootdir, target_source_filepath, nb_link)
         return markdown_text
 
     @classmethod
-    def replace_notebook_link(cls, markdown_text: str, nb_dir:str, source_filepath:str, nb_link:str) -> str:
-
-        file_path = os.path.normpath(os.path.join(nb_dir, source_filepath))
-        if not cls.file_exists(file_path):
+    def replace_notebook_link(cls, markdown_text: str, rootdir:str, target_relpath:str, nb_link:str) -> str:
+        target_abspath = os.path.normpath(os.path.join(rootdir, target_relpath))
+        if not cls.file_exists(target_abspath):
             return markdown_text 
-        new_link = cls._create_target_link(nb_link, source_filepath)
+        new_link = cls._create_target_link(nb_link, target_relpath)
         return markdown_text.replace(nb_link, new_link)
 
     @staticmethod

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -244,8 +244,10 @@ class FixNotebookLinks(Preprocessor):
         >>> list(_get_potential_link_targets("01-notebook.ipynb"))
         ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"]
         """
-        assert notebook_filename.endswith('.ipynb'), 'The file extension must be .ipynb'
-        stem = notebook_filename[:-5]
+        if not notebook_filename.endswith('.ipynb'):
+            raise ValueError('The file extension must be .ipynb')
+
+        stem = notebook_filename[:-6]
 
         for extension in cls.file_types:
             yield f"{stem}.{extension}"

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -220,25 +220,29 @@ class FixNotebookLinks(Preprocessor):
                     continue
                 new_link = cls._create_target_link(nb_link, target_filename)
                 markdown_text = markdown_text.replace(nb_link, new_link)
-                break # each notebook_stem may have only one source target filename
+                break # each notebook link may have only one source target filename
 
         return markdown_text
 
     @staticmethod
     def _extract_links(markdown_text: str) -> Iterable[Tuple[str, str]]:
-        """Find links to Notebook files (.ipynb) from markdown text and return
-        them. Returns the full link and the link target separately.
+        """Extract links to Notebook files (.ipynb) from markdown text and
+        yield them. Returns the full markdown link and the link target 
+        separately.
         
-        Example
-        -------
-        String "foo [a](b.ipynb) bar [c](d.ipynb)" would return iterable, which
-        when converted to a list would be: [
-             [('[a](b.ipynb)', 'b')]
-             [('[c](d.ipynb)', 'd')]
+        Examples
+        --------
+        Mmarkdown link: "[a](../foo/b.ipynb#spam)" 
+        Link target: "..foo/b.ipynb"
+        
+        String "foo [a](b.ipynb) bar [c](..foo/d.ipynb#spam)" would return
+        iterable, which when converted to a list would be: [
+             [('[a](b.ipynb)', 'b.ipynb')]
+             [('[c](../foo/d.ipynb#spam)', '../foo/d.ipynb')]
         ] 
 
         """
-        for match in re.finditer(r"(\[.+?\]\((.+?)\.ipynb#*?.*?\))", markdown_text):
+        for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)#*?.*?\))", markdown_text):
             yield match.groups()
 
     @classmethod

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -214,7 +214,7 @@ class FixNotebookLinks(Preprocessor):
         return cell, resources
 
     @staticmethod
-    def _get_links(markdown_text: str) -> Iterable[Tuple[str, str]]:
+    def _extract_links(markdown_text: str) -> Iterable[Tuple[str, str]]:
         """Find links to Notebook files (.ipynb) from markdown text and return
         them. Returns the full link and the link target separately.
         

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -261,6 +261,12 @@ class FixNotebookLinks(Preprocessor):
         If nb_link is "[sometext](.q./../somepath/01-subject.ipynb#spam)", and
         the target_filename is "subject.rst", returns
         "[sometext](../../somepath/subject.rst#spam)"
+
+        Notes:
+        * If you pass as nb_link text which contains no markdown links, a
+          ValueError will be raised
+        * If you pass as nb_link text which contains more than one markdown
+          links, the behaviour is undefined.
         """
 
         # Example: [sometext](../../somepath/subject.ipynb#spam)

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -232,7 +232,18 @@ class FixNotebookLinks(Preprocessor):
 
     @classmethod
     def _get_potential_link_targets(cls, notebook_filename: str) -> Iterable[str]:
+        """Gets potential link targets corresponding to a notebook filename
+        Potential link targets are formed by using the stem of the notebook
+        filename, and adding the extensions from `cls.file_types`. In addition
+        if the notebook_filename starts with digits + one of ('-', '_', ' '),
+        the stem without the number prefix is used to form a potential link
+        target.
 
+        Example
+        -------
+        >>> list(_get_potential_link_targets("01-notebook.ipynb"))
+        ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"]
+        """
         stem, extension = notebook_filename.rsplit('.', maxsplit=1)
         assert extension == 'ipynb', 'The file extension must be .ipynb'
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -244,8 +244,8 @@ class FixNotebookLinks(Preprocessor):
         >>> list(_get_potential_link_targets("01-notebook.ipynb"))
         ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"]
         """
-        stem, extension = notebook_filename.rsplit('.', maxsplit=1)
-        assert extension == 'ipynb', 'The file extension must be .ipynb'
+        assert notebook_filename.endswith('.ipynb'), 'The file extension must be .ipynb'
+        stem = notebook_filename[:-5]
 
         for extension in cls.file_types:
             yield f"{stem}.{extension}"

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -324,7 +324,7 @@ class FixNotebookLinks(Preprocessor):
 
     @staticmethod
     def file_exists(file_path: str) -> bool:
-        return not os.path.isfile(file_path)
+        return os.path.isfile(file_path)
 
     def __call__(self, nb, resources):
         return self.preprocess(nb,resources)

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -27,7 +27,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-
+from __future__ import annotations
 import copy
 import glob
 import io
@@ -37,6 +37,8 @@ import re
 import shutil
 import string
 import sys
+import typing
+
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -53,6 +55,11 @@ from nbconvert.preprocessors import (
 )
 
 from .cmd import _prepare_paths, hosts
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Tuple
+
 
 NOTEBOOK_VERSION = 4
 
@@ -205,6 +212,23 @@ class FixNotebookLinks(Preprocessor):
                     )
                     break
         return cell, resources
+
+    @staticmethod
+    def _get_links(markdown_text: str) -> Iterable[Tuple[str, str]]:
+        """Find links from markdown text and return them. Returns the full link
+        and the link target separately.
+        
+        Example
+        -------
+        String "foo [a](b.ipynb) bar [c](d.ipynb)" would return iterable, which
+        when converted to a list would be: [
+             [('[a](b.ipynb)', 'b.ipynb')]
+             [('[c](d.ipynb)', 'd.ipynb')]
+        ] 
+
+        """
+        for match in re.finditer(r"(\[.+\]\((.+\.ipynb)\))", markdown_text):
+            yield match.groups()
 
     def __call__(self, nb, resources):
         return self.preprocess(nb,resources)

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -292,15 +292,15 @@ class FixNotebookLinks(Preprocessor):
 
 
     @staticmethod
-    def _create_target_link(nb_link: str, target_filename:str) -> str:
+    def _create_target_link(nb_link: str, target_relpath:str) -> str:
         """Using a markdown link `nb_link`, create a markdown link which
-        changes the target filename to be `target_filename`.
+        changes the link target file to be `target_relpath`.
 
         Example
         -------
-        If nb_link is "[sometext](.q./../somepath/01-subject.ipynb#spam)", and
-        the target_filename is "subject.rst", returns
-        "[sometext](../../somepath/subject.rst#spam)"
+        If nb_link is "[sometext](../../somepath/01-subject.ipynb#spam)", and
+        the target_filename is "../otherpath/subject.rst", returns
+        "[sometext](../otherpath/subject.rst#spam)"
 
         Notes:
         * If you pass as nb_link text which contains no markdown links, a
@@ -322,12 +322,7 @@ class FixNotebookLinks(Preprocessor):
         if not match:
             raise ValueError(f'Not a valid markdown link!: {nb_link}')
 
-        start, nb_path_part, _, end =  match.groups()
-
-        # Extract "../../somepath/" from "../../somepath/subject"
-        path_beginning = ''.join(re.split('(/)', nb_path_part)[:-1])
-
-        return f"{start}{path_beginning}{target_filename}{end}"
+        return f"{match.group(1)}{target_relpath}{match.group(4)}"
 
     @staticmethod
     def file_exists(file_path: str) -> bool:

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -239,9 +239,9 @@ class FixNotebookLinks(Preprocessor):
         for extension in cls.file_types:
             yield f"{stem}.{extension}"
 
-            match = re.match(r"\d+[ |-|_](.*)", stem)
+            match = re.match(r"\d+[ -_](.*)", stem)
             if match:
-                yield match.group(1)
+                yield f"{match.group(1)}.{extension}"
 
     def __call__(self, nb, resources):
         return self.preprocess(nb,resources)

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -251,6 +251,38 @@ class FixNotebookLinks(Preprocessor):
             if match:
                 yield f"{match.group(1)}.{extension}"
 
+    @staticmethod
+    def _create_target_link(nb_link: str, target_filename:str) -> str:
+        """Using a markdown link `nb_link`, create a markdown link which
+        changes the target filename to be `target_filename`.
+
+        Example
+        -------
+        If nb_link is "[sometext](.q./../somepath/01-subject.ipynb#spam)", and
+        the target_filename is "subject.rst", returns
+        "[sometext](../../somepath/subject.rst#spam)"
+        """
+
+        # Example: [sometext](../../somepath/subject.ipynb#spam)
+        match = re.match(
+            (
+                r"^(\[.+?\]\()"  # [sometext](
+                r"(.+?)"         #  ../../somepath/subject
+                r"(\.ipynb)"     # .ipynb
+                r"(#*?.*?\))"    # #spam)
+            ),
+            nb_link,
+        )
+        if not match:
+            raise ValueError(f'Not a valid markdown link!: {nb_link}')
+
+        start, nb_path_part, _, end =  match.groups()
+
+        # Extract "../../somepath/" from "../../somepath/subject"
+        path_beginning = ''.join(re.split('(/)', nb_path_part)[:-1])
+
+        return f"{start}{path_beginning}{target_filename}{end}"
+
     def __call__(self, nb, resources):
         return self.preprocess(nb,resources)
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -230,6 +230,19 @@ class FixNotebookLinks(Preprocessor):
         for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)#*?.*?\))", markdown_text):
             yield match.groups()
 
+    @classmethod
+    def _get_potential_link_targets(cls, notebook_filename: str) -> Iterable[str]:
+
+        stem, extension = notebook_filename.rsplit('.', maxsplit=1)
+        assert extension == 'ipynb', 'The file extension must be .ipynb'
+
+        for extension in cls.file_types:
+            yield f"{stem}.{extension}"
+
+            match = re.match(r"\d+[ |-|_](.*)", stem)
+            if match:
+                yield match.group(1)
+
     def __call__(self, nb, resources):
         return self.preprocess(nb,resources)
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -227,7 +227,7 @@ class FixNotebookLinks(Preprocessor):
         ] 
 
         """
-        for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)\))", markdown_text):
+        for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)#*?.*?\))", markdown_text):
             yield match.groups()
 
     def __call__(self, nb, resources):

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -264,8 +264,13 @@ class FixNotebookLinks(Preprocessor):
 
         Example
         -------
-        >>> list(_get_potential_link_targets("01-notebook.ipynb"))
-        ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"]
+        >>> list(_get_potential_link_targets("../foo/01-Some_Notebook.ipynb"))
+        [
+            "../foo/01-Some_Notebook.rst",
+            "../foo/01-Some_Notebook.md",
+            "../foo/Some_Notebook.rst",
+            "../foo/Some_Notebook.md",
+        ],
         """
 
         if not nb_filepath.endswith('.ipynb'):
@@ -275,6 +280,7 @@ class FixNotebookLinks(Preprocessor):
         for extension in cls.file_types:
             yield f"{nb_path_without_extension}.{extension}"
 
+        for extension in cls.file_types:
             *directory, stem = re.split('(/)', nb_path_without_extension)
             match = re.match(r"\d+[ -_](.*)", stem)
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -215,8 +215,8 @@ class FixNotebookLinks(Preprocessor):
 
     @staticmethod
     def _get_links(markdown_text: str) -> Iterable[Tuple[str, str]]:
-        """Find links from markdown text and return them. Returns the full link
-        and the link target separately.
+        """Find links to Notebook files (.ipynb) from markdown text and return
+        them. Returns the full link and the link target separately.
         
         Example
         -------

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -222,17 +222,17 @@ class FixNotebookLinks(Preprocessor):
         -------
         String "foo [a](b.ipynb) bar [c](d.ipynb)" would return iterable, which
         when converted to a list would be: [
-             [('[a](b.ipynb)', 'b.ipynb')]
-             [('[c](d.ipynb)', 'd.ipynb')]
+             [('[a](b.ipynb)', 'b')]
+             [('[c](d.ipynb)', 'd')]
         ] 
 
         """
-        for match in re.finditer(r"(\[.+?\]\((.+?\.ipynb)#*?.*?\))", markdown_text):
+        for match in re.finditer(r"(\[.+?\]\((.+?)\.ipynb#*?.*?\))", markdown_text):
             yield match.groups()
 
     @classmethod
-    def _get_potential_link_targets(cls, notebook_filename: str) -> Iterable[str]:
-        """Gets potential link targets corresponding to a notebook filename
+    def _get_potential_link_targets(cls, notebook_stem: str) -> Iterable[str]:
+        """Gets potential link targets corresponding to a notebook file stem.
         Potential link targets are formed by using the stem of the notebook
         filename, and adding the extensions from `cls.file_types`. In addition
         if the notebook_filename starts with digits + one of ('-', '_', ' '),
@@ -241,18 +241,13 @@ class FixNotebookLinks(Preprocessor):
 
         Example
         -------
-        >>> list(_get_potential_link_targets("01-notebook.ipynb"))
+        >>> list(_get_potential_link_targets("01-notebook"))
         ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"]
         """
-        if not notebook_filename.endswith('.ipynb'):
-            raise ValueError('The file extension must be .ipynb')
-
-        stem = notebook_filename[:-6]
-
         for extension in cls.file_types:
-            yield f"{stem}.{extension}"
+            yield f"{notebook_stem}.{extension}"
 
-            match = re.match(r"\d+[ -_](.*)", stem)
+            match = re.match(r"\d+[ -_](.*)", notebook_stem)
             if match:
                 yield f"{match.group(1)}.{extension}"
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -233,7 +233,7 @@ class FixNotebookLinks(Preprocessor):
         
         Examples
         --------
-        Mmarkdown link: "[a](../foo/b.ipynb#spam)" 
+        Markdown link: "[a](../foo/b.ipynb#spam)" 
         Link target: "..foo/b.ipynb"
         
         String "foo [a](b.ipynb) bar [c](..foo/d.ipynb#spam)" would return

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -83,8 +83,8 @@ class TestFixNotebookLinks:
             ("[a](b.ipynb#spam)", "file.rst", "[a](file.rst#spam)"),
             (
                 "[sometext](../../somepath/subject.ipynb#spam)",
-                "file.rst",
-                "[sometext](../../somepath/file.rst#spam)",
+                "../../otherpath/file.rst",
+                "[sometext](../../otherpath/file.rst#spam)",
             ),
         ],
     )
@@ -94,7 +94,7 @@ class TestFixNotebookLinks:
             == expected_output
         )
 
-    def test_replace_notebook_links(self, monkeypatch):
+    def test_replace_notebook_links(self):
 
         nb_dir = "/tmp/somepath/user_guide"
 

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -8,8 +8,15 @@ class TestFixNotebookLinks:
     @pytest.mark.parametrize(
         "markdowntext, expected_output",
         [
+            # Case: one link in the text
             ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
+            # Case: no link to .ipynb
             ("foo [a](b.md) bar", []),
+            # Case: two links in the text
+            (
+                "foo [a](b.ipynb) bar [c](d.ipynb) baz.",
+                [("[a](b.ipynb)", "b.ipynb"), ("[c](d.ipynb)", "d.ipynb")],
+            ),
         ],
     )
     def test_get_links(self, markdowntext, expected_output):

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -10,12 +10,22 @@ class TestFixNotebookLinks:
         [
             # Case: one link in the text
             ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
-            # Case: no link to .ipynb
+            # Case: no link to .ipynb 
             ("foo [a](b.md) bar", []),
             # Case: two links in the text
             (
                 "foo [a](b.ipynb) bar [c](d.ipynb) baz.",
                 [("[a](b.ipynb)", "b.ipynb"), ("[c](d.ipynb)", "d.ipynb")],
+            ),
+            # Case: Link has an anchor
+            (
+                "foo [a](b.ipynb#some-anchor) bar",
+                [("[a](b.ipynb#some-anchor)", "b.ipynb")],
+            ),
+            # Case: Two links has an anchor
+            (
+                "foo [a](b.ipynb#spam) bar [c](d.ipynb#eggs) baz.",
+                [("[a](b.ipynb#spam)", "b.ipynb"), ("[c](d.ipynb#eggs)", "d.ipynb")],
             ),
         ],
     )

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -1,9 +1,16 @@
+import pytest
+
 from nbsite.nbbuild import FixNotebookLinks
 
 
 class TestFixNotebookLinks:
 
-
-    def test_get_links(self):
-        assert list(FixNotebookLinks._get_links('foo [a](b.ipynb) bar')) == [('[a](b.ipynb)', 'b.ipynb')]
-        assert list(FixNotebookLinks._get_links('foo [a](b.md) bar')) == []
+    @pytest.mark.parametrize(
+        "markdowntext, expected_output",
+        [
+            ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
+            ("foo [a](b.md) bar", []),
+        ],
+    )
+    def test_get_links(self, markdowntext, expected_output):
+        assert list(FixNotebookLinks._get_links(markdowntext)) == expected_output

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -1,0 +1,9 @@
+from nbsite.nbbuild import FixNotebookLinks
+
+
+class TestFixNotebookLinks:
+
+
+    def test_get_links(self):
+        assert list(FixNotebookLinks._get_links('foo [a](b.ipynb) bar')) == [('[a](b.ipynb)', 'b.ipynb')]
+        assert list(FixNotebookLinks._get_links('foo [a](b.md) bar')) == []

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -53,3 +53,21 @@ class TestFixNotebookLinks:
     def test_get_potential_link_targets(self, notebook_stem, expected_output):
         output = list(FixNotebookLinks._get_potential_link_targets(notebook_stem))
         assert output == expected_output
+
+    @pytest.mark.parametrize(
+        "nb_link, target_filename, expected_output",
+        [
+            ("[a](b.ipynb)", "file.rst", "[a](file.rst)"),
+            ("[a](b.ipynb#spam)", "file.rst", "[a](file.rst#spam)"),
+            (
+                "[sometext](../../somepath/subject.ipynb#spam)",
+                "file.rst",
+                "[sometext](../../somepath/file.rst#spam)",
+            ),
+        ],
+    )
+    def test_create_target_link(self, nb_link, target_filename, expected_output):
+        assert (
+            FixNotebookLinks._create_target_link(nb_link, target_filename)
+            == expected_output
+        )

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -42,19 +42,28 @@ class TestFixNotebookLinks:
 
     @pytest.mark.parametrize(
         "notebook_stem, expected_output",
-        [
-            ("notebook", ["notebook.rst", "notebook.md"]),
+        [   
+            # simple
+            ("notebook.ipynb", ["notebook.rst", "notebook.md"]),
             (
-                "01 notebook",
+                # Numeric with space
+                "01 notebook.ipynb",
                 ["01 notebook.rst", "notebook.rst", "01 notebook.md", "notebook.md"],
             ),
             (
-                "01-notebook",
+                # Numeric with dash
+                "01-notebook.ipynb",
                 ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"],
             ),
             (
-                "01_notebook",
+                # Numeric with underscore
+                "01_notebook.ipynb",
                 ["01_notebook.rst", "notebook.rst", "01_notebook.md", "notebook.md"],
+            ),
+            (
+                # Numeric with relative path
+                "../foo/01_notebook.ipynb",
+                ["../foo/01_notebook.rst", "../foo/notebook.rst", "../foo/01_notebook.md", "../foo/notebook.md"],
             ),
         ],
     )

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -54,3 +54,7 @@ class TestFixNotebookLinks:
     def test_get_potential_link_targets(self, notebook_filename, expected_output):
         output = list(FixNotebookLinks._get_potential_link_targets(notebook_filename))
         assert output == expected_output
+
+    def test_get_potential_link_targets_valueerror(self):
+        with pytest.raises(ValueError, match="The file extension must be .ipynb"):
+            list(FixNotebookLinks._get_potential_link_targets("foo.md"))

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -9,23 +9,23 @@ class TestFixNotebookLinks:
         "markdowntext, expected_output",
         [
             # Case: one link in the text
-            ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
+            ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b")]),
             # Case: no link to .ipynb
             ("foo [a](b.md) bar", []),
             # Case: two links in the text
             (
                 "foo [a](b.ipynb) bar [c](d.ipynb) baz.",
-                [("[a](b.ipynb)", "b.ipynb"), ("[c](d.ipynb)", "d.ipynb")],
+                [("[a](b.ipynb)", "b"), ("[c](d.ipynb)", "d")],
             ),
             # Case: Link has an anchor
             (
                 "foo [a](b.ipynb#some-anchor) bar",
-                [("[a](b.ipynb#some-anchor)", "b.ipynb")],
+                [("[a](b.ipynb#some-anchor)", "b")],
             ),
             # Case: Two links has an anchor
             (
                 "foo [a](b.ipynb#spam) bar [c](d.ipynb#eggs) baz.",
-                [("[a](b.ipynb#spam)", "b.ipynb"), ("[c](d.ipynb#eggs)", "d.ipynb")],
+                [("[a](b.ipynb#spam)", "b"), ("[c](d.ipynb#eggs)", "d")],
             ),
         ],
     )
@@ -33,28 +33,23 @@ class TestFixNotebookLinks:
         assert list(FixNotebookLinks._extract_links(markdowntext)) == expected_output
 
     @pytest.mark.parametrize(
-        "notebook_filename, expected_output",
+        "notebook_stem, expected_output",
         [
-            # Case: Simple notebook name. No numbers
-            ("notebook.ipynb", ["notebook.rst", "notebook.md"]),
+            ("notebook", ["notebook.rst", "notebook.md"]),
             (
-                "01 notebook.ipynb",
+                "01 notebook",
                 ["01 notebook.rst", "notebook.rst", "01 notebook.md", "notebook.md"],
             ),
             (
-                "01-notebook.ipynb",
+                "01-notebook",
                 ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"],
             ),
             (
-                "01_notebook.ipynb",
+                "01_notebook",
                 ["01_notebook.rst", "notebook.rst", "01_notebook.md", "notebook.md"],
             ),
         ],
     )
-    def test_get_potential_link_targets(self, notebook_filename, expected_output):
-        output = list(FixNotebookLinks._get_potential_link_targets(notebook_filename))
+    def test_get_potential_link_targets(self, notebook_stem, expected_output):
+        output = list(FixNotebookLinks._get_potential_link_targets(notebook_stem))
         assert output == expected_output
-
-    def test_get_potential_link_targets_valueerror(self):
-        with pytest.raises(ValueError, match="The file extension must be .ipynb"):
-            list(FixNotebookLinks._get_potential_link_targets("foo.md"))

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -48,22 +48,22 @@ class TestFixNotebookLinks:
             (
                 # Numeric with space
                 "01 notebook.ipynb",
-                ["01 notebook.rst", "notebook.rst", "01 notebook.md", "notebook.md"],
+                ["01 notebook.rst", "01 notebook.md", "notebook.rst","notebook.md"],
             ),
             (
                 # Numeric with dash
                 "01-notebook.ipynb",
-                ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"],
+                ["01-notebook.rst",  "01-notebook.md", "notebook.rst","notebook.md"],
             ),
             (
                 # Numeric with underscore
                 "01_notebook.ipynb",
-                ["01_notebook.rst", "notebook.rst", "01_notebook.md", "notebook.md"],
+                ["01_notebook.rst", "01_notebook.md","notebook.rst",  "notebook.md"],
             ),
             (
                 # Numeric with relative path
                 "../foo/01_notebook.ipynb",
-                ["../foo/01_notebook.rst", "../foo/notebook.rst", "../foo/01_notebook.md", "../foo/notebook.md"],
+                ["../foo/01_notebook.rst", "../foo/01_notebook.md","../foo/notebook.rst",  "../foo/notebook.md"],
             ),
         ],
     )

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -29,5 +29,5 @@ class TestFixNotebookLinks:
             ),
         ],
     )
-    def test_get_links(self, markdowntext, expected_output):
-        assert list(FixNotebookLinks._get_links(markdowntext)) == expected_output
+    def test_extract_links(self, markdowntext, expected_output):
+        assert list(FixNotebookLinks._extract_links(markdowntext)) == expected_output

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -42,33 +42,38 @@ class TestFixNotebookLinks:
 
     @pytest.mark.parametrize(
         "notebook_stem, expected_output",
-        [   
+        [
             # simple
             ("notebook.ipynb", ["notebook.rst", "notebook.md"]),
             (
                 # Numeric with space
                 "01 notebook.ipynb",
-                ["01 notebook.rst", "01 notebook.md", "notebook.rst","notebook.md"],
+                ["01 notebook.rst", "01 notebook.md", "notebook.rst", "notebook.md"],
             ),
             (
                 # Numeric with dash
                 "01-notebook.ipynb",
-                ["01-notebook.rst",  "01-notebook.md", "notebook.rst","notebook.md"],
+                ["01-notebook.rst", "01-notebook.md", "notebook.rst", "notebook.md"],
             ),
             (
                 # Numeric with underscore
                 "01_notebook.ipynb",
-                ["01_notebook.rst", "01_notebook.md","notebook.rst",  "notebook.md"],
+                ["01_notebook.rst", "01_notebook.md", "notebook.rst", "notebook.md"],
             ),
             (
                 # Numeric with relative path
                 "../foo/01_notebook.ipynb",
-                ["../foo/01_notebook.rst", "../foo/01_notebook.md","../foo/notebook.rst",  "../foo/notebook.md"],
+                [
+                    "../foo/01_notebook.rst",
+                    "../foo/01_notebook.md",
+                    "../foo/notebook.rst",
+                    "../foo/notebook.md",
+                ],
             ),
         ],
     )
-    def test_get_potential_link_targets(self, notebook_stem, expected_output):
-        output = list(FixNotebookLinks._get_potential_link_targets(notebook_stem))
+    def test_iter_source_file_candidates(self, notebook_stem, expected_output):
+        output = list(FixNotebookLinks._iter_source_file_candidates(notebook_stem))
         assert output == expected_output
 
     @pytest.mark.parametrize(

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -12,23 +12,28 @@ class TestFixNotebookLinks:
         "markdowntext, expected_output",
         [
             # Case: one link in the text
-            ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b")]),
+            ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
             # Case: no link to .ipynb
             ("foo [a](b.md) bar", []),
             # Case: two links in the text
             (
                 "foo [a](b.ipynb) bar [c](d.ipynb) baz.",
-                [("[a](b.ipynb)", "b"), ("[c](d.ipynb)", "d")],
+                [("[a](b.ipynb)", "b.ipynb"), ("[c](d.ipynb)", "d.ipynb")],
             ),
             # Case: Link has an anchor
             (
                 "foo [a](b.ipynb#some-anchor) bar",
-                [("[a](b.ipynb#some-anchor)", "b")],
+                [("[a](b.ipynb#some-anchor)", "b.ipynb")],
             ),
             # Case: Two links has an anchor
             (
                 "foo [a](b.ipynb#spam) bar [c](d.ipynb#eggs) baz.",
-                [("[a](b.ipynb#spam)", "b"), ("[c](d.ipynb#eggs)", "d")],
+                [("[a](b.ipynb#spam)", "b.ipynb"), ("[c](d.ipynb#eggs)", "d.ipynb")],
+            ),
+            # Case: Relative path
+            (
+                "foo [a](../foo/b.ipynb#spam) bar.",
+                [("[a](../foo/b.ipynb#spam)", "../foo/b.ipynb")],
             ),
         ],
     )
@@ -77,7 +82,8 @@ class TestFixNotebookLinks:
 
     def test_replace_notebook_links(self, monkeypatch):
 
-        nb_dir = '/tmp/somepath/user_guide'
+        nb_dir = "/tmp/somepath/user_guide"
+
         class FixNotebookLinksMockFiles(FixNotebookLinks):
 
             @staticmethod
@@ -85,10 +91,10 @@ class TestFixNotebookLinks:
                 normalized_path = os.path.normpath(file_path)
                 # mock existence of certain fiels
                 return normalized_path in {
-                    '/tmp/somepath/user_guide/first.rst',
-                    '/tmp/somepath/user_guide/02-Second_Notebook.md',
-                    '/tmp/notebooks/Third_Notebook.rst',
-                    '/tmp/somepath/foo/Notebook.rst',
+                    "/tmp/somepath/user_guide/first.rst",
+                    "/tmp/somepath/user_guide/02-Second_Notebook.md",
+                    "/tmp/notebooks/Third_Notebook.rst",
+                    "/tmp/somepath/foo/Notebook.rst",
                 }
 
         text = textwrap.dedent(
@@ -126,7 +132,6 @@ class TestFixNotebookLinks:
                 "\n"
             )
         )
-
 
         processor = FixNotebookLinksMockFiles(nb_dir)
         assert processor.replace_notebook_links(text, nb_dir) == expected_output

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -31,3 +31,16 @@ class TestFixNotebookLinks:
     )
     def test_extract_links(self, markdowntext, expected_output):
         assert list(FixNotebookLinks._extract_links(markdowntext)) == expected_output
+
+
+    @pytest.mark.parametrize(
+        "notebook_filename, expected_output",
+        [
+            # Case: Simple notebook name. No numbers
+            ("notebook.ipynb", ['notebook.rst', 'notebook.md']),
+
+        ],
+    )
+    def test_get_potential_link_targets(self, notebook_filename, expected_output):
+        assert list(FixNotebookLinks._get_potential_link_targets(notebook_filename)) == expected_output
+

--- a/nbsite/tests/test_nbbuild.py
+++ b/nbsite/tests/test_nbbuild.py
@@ -10,7 +10,7 @@ class TestFixNotebookLinks:
         [
             # Case: one link in the text
             ("foo [a](b.ipynb) bar", [("[a](b.ipynb)", "b.ipynb")]),
-            # Case: no link to .ipynb 
+            # Case: no link to .ipynb
             ("foo [a](b.md) bar", []),
             # Case: two links in the text
             (
@@ -32,15 +32,25 @@ class TestFixNotebookLinks:
     def test_extract_links(self, markdowntext, expected_output):
         assert list(FixNotebookLinks._extract_links(markdowntext)) == expected_output
 
-
     @pytest.mark.parametrize(
         "notebook_filename, expected_output",
         [
             # Case: Simple notebook name. No numbers
-            ("notebook.ipynb", ['notebook.rst', 'notebook.md']),
-
+            ("notebook.ipynb", ["notebook.rst", "notebook.md"]),
+            (
+                "01 notebook.ipynb",
+                ["01 notebook.rst", "notebook.rst", "01 notebook.md", "notebook.md"],
+            ),
+            (
+                "01-notebook.ipynb",
+                ["01-notebook.rst", "notebook.rst", "01-notebook.md", "notebook.md"],
+            ),
+            (
+                "01_notebook.ipynb",
+                ["01_notebook.rst", "notebook.rst", "01_notebook.md", "notebook.md"],
+            ),
         ],
     )
     def test_get_potential_link_targets(self, notebook_filename, expected_output):
-        assert list(FixNotebookLinks._get_potential_link_targets(notebook_filename)) == expected_output
-
+        output = list(FixNotebookLinks._get_potential_link_targets(notebook_filename))
+        assert output == expected_output


### PR DESCRIPTION
This PR attempts to fix
- https://github.com/holoviz-dev/nbsite/issues/297
- https://github.com/holoviz/holoviews/issues/6086
- Some parts of https://github.com/holoviz/holoviews/issues/5676 (to be seen)

## What was done?

The "notebook" directive uses a subclass of nbconvert.preprocessors.PreProcessor called FixNotebookLinks to fix links in Jupyter Notebooks markdown cells. For example 

```
[customization](../getting_started/2-Customization.ipynb) 
```

should be converted to

```
[customization]((../getting_started/Customization.rst) 
```

If there exists is Customization.rst source file (the file with notebook directive) in the ../getting_started/ directory. If the link target notebook is not in the same directory as the notebook where the link is, the current version won't create a link, and during sphinx-build myst warns about a missing reference target like this:

```
WARNING: 'myst' reference target not found: ../getting_started/2-Customization.ipynb
or
WARNING: 'myst' reference target not found: Customization.rst
```

I'm not completely sure why the first type of warnings were emitted (reference target is .ipynb), but the second type of warning (reference target is .rst file) occurred because in the old implementation the "target" in `[some text](target)` was replaced completely by the found source (.rst or .md) file. That means that with file structure 

```
📁 examples/
├─📁 user_guide/
│ ├─📄 03-Applying_Customizations.ipynb
│ └─📄 04-Style_Mapping.ipynb
└─📁 getting_started/
  └─📄 2-Customization.ipynb
```

and 

```
- Here is a link to [customization](../getting_started/2-Customization.ipynb)
```

in `examples/user_guide/03-Applying_Customizations.ipynb` one would get 

```
- Here is a link to [customization](Customization.rst)
```

in the doctree for sphinx, instead of 

```
- Here is a link to [customization](../getting_started/Customization.rst)
```

In addition to this, any anchors like #spam in `[customization](../getting_started/2-Customization.ipynb#spam)` would be removed.

This PR fixes those issues by making a

```
[customization](../getting_started/2-Customization.ipynb#spam)
```

to be 

```
[customization](../getting_started/2-Customization.rst#spam)
or
[customization](../getting_started/2-Customization.md#spam)
or
[customization](../getting_started/Customization.rst#spam)
or 
[customization](../getting_started/Customization.md#spam)
```

depending on which of the source files (.rst/.md) is found first, if any.

## How to test this?

Testing this is a bit difficult as explained [here](https://github.com/holoviz/holoviews/issues/6086#issuecomment-1925307321), but you may install the "bottom-up MWE" from https://github.com/fohrloop/holoviews-issue-6086-mwe and build the docs with

```
nbsite build --what=html --output=builtdocs --org holoviz --project-name holoviews
```

Or, after first build (when /docs has the .ipynb files), with

```
sphinx-build -b html doc/ builtdocs/ -a
```

### Without these changes

With the current nbsite version, one would expect to see a broken link

![image](https://github.com/holoviz-dev/nbsite/assets/17479683/170979bd-6aed-464f-809d-d794d6fce3f6)

and following warning during build process:

```                                               
/home/niko/tmp/minimal-doc-error/doc/user_guide/03-Applying_Customizations.ipynb:20003: WARNING: 'myst' reference target not found: Customization.rst
```

### With these changes

One should see:

![image](https://github.com/holoviz-dev/nbsite/assets/17479683/051e967e-d1a7-4d3c-a8f2-a7962de598ad)

and the build process output should not have the abovementioned reference target not found warning.

## About the code

- I was not aware of the style guide and and linting / formatting tools used. The code in `nbsite/nbbuild.py` is not formatted using any tools. The test module is formatted using black. Please instruct how you would like the code to be formatted.

