### PR TITLE
Set UTF8 encoding when writing text files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.doit*
 pip-wheel-metadata
 .tox
+.venv/
 
 # ipython
 */.ipynb_checkpoints

--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -499,7 +499,7 @@ def generate_section_index(section, items, dest_dir, rel='..', title=None):
     index_page += '\n' + title + '\n' + '_'*len(title) + '\n'
     index_page += '\n\n.. toctree::\n   :glob:\n   :hidden:\n\n   '
     index_page += '\n   '.join(items)
-    with open(os.path.join(dest_dir, 'index.rst'), 'w') as f:
+    with open(os.path.join(dest_dir, 'index.rst'), 'w', encoding='utf-8') as f:
         f.write(index_page)
 
 def _normalize_label(string):
@@ -837,7 +837,7 @@ def generate_gallery(app, page):
 
     if backends or section_backends:
         gallery_rst += HIDE_JS.format(backends=repr(backends[1:]))
-    with open(os.path.join(doc_dir, page, 'index.rst'), 'w') as f:
+    with open(os.path.join(doc_dir, page, 'index.rst'), 'w', encoding='utf-8') as f:
         f.write(gallery_rst)
 
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -434,11 +434,11 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,
         os.chdir(cwd)
 
         if skip_execute:
-            nbformat.write(notebook, open(dest_path, 'w'))
+            nbformat.write(notebook, open(dest_path, 'w', encoding='utf-8'))
         else:
             ne = NotebookExporter()
             newnb, _ = ne.from_notebook_node(notebook)
-            with open(dest_path,'w') as f:
+            with open(dest_path, 'w', encoding='utf-8') as f:
                 f.write(newnb)
             for pattern in patterns_to_take_with_me:
                 for f in glob.glob(os.path.join(os.path.dirname(nb_path),pattern)):
@@ -540,7 +540,7 @@ class NotebookDirective(Directive):
             dest_path_script = string.replace(dest_path, '.ipynb', '.py')
             rel_path_script = string.replace(nb_basename, '.ipynb', '.py')
             script_text = nb_to_python(nb_abs_path)
-            f = open(dest_path_script, 'w')
+            f = open(dest_path_script, 'w', encoding='utf-8')
             f.write(script_text.encode('utf8'))
             f.close()
 

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -356,12 +356,12 @@ def write_worker(app: Sphinx, exc):
         'autodetect_deps': pyodide_conf['autodetect_deps'],
         'requires': json.dumps(pyodide_conf['requires'])
     })
-    with open(staticdir/ 'PyodideWebWorker.js', 'w') as f:
+    with open(staticdir/ 'PyodideWebWorker.js', 'w', encoding='utf-8') as f:
         f.write(web_worker)
     worker_setup = WORKER_HANDLER_TEMPLATE.render(
         scripts=pyodide_conf['scripts']
     )
-    with open(staticdir/ 'WorkerHandler.js', 'w') as f:
+    with open(staticdir/ 'WorkerHandler.js', 'w', encoding='utf-8') as f:
         f.write(worker_setup)
 
     if not pyodide_conf['enable_pwa']:
@@ -374,17 +374,17 @@ def write_worker(app: Sphinx, exc):
         'pre_cache': ', '.join([repr(req) for req in pyodide_conf['precache']]),
         'cache_patterns': ', '.join([repr(req) for req in pyodide_conf['cache_patterns']])
     })
-    with open(builddir / 'PyodideServiceWorker.js', 'w') as f:
+    with open(builddir / 'PyodideServiceWorker.js', 'w', encoding='utf-8') as f:
         f.write(service_worker)
     service_handler = SERVICE_HANDLER_TEMPLATE.render()
-    with open(staticdir/ 'ServiceHandler.js', 'w') as f:
+    with open(staticdir/ 'ServiceHandler.js', 'w', encoding='utf-8') as f:
         f.write(service_handler)
 
     # Render manifest
     site_manifest = WEB_MANIFEST_TEMPLATE.render({
         'name': app.config.html_title,
     })
-    with open(builddir / 'site.webmanifest', 'w') as f:
+    with open(builddir / 'site.webmanifest', 'w', encoding='utf-8') as f:
         f.write(site_manifest)
 
 

--- a/scripts/nbsite_fix_links.py
+++ b/scripts/nbsite_fix_links.py
@@ -122,7 +122,7 @@ def cleanup_links(path, inspect_links=False):
                     img['src'] = also_tried
                 else:
                     warnings.warn('Found reference to missing image {} in: {}. Also tried: {}'.format(src, path, also_tried))
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(str(soup))
 
 if __name__ == '__main__':

--- a/scripts/nbsite_generate_modules.py
+++ b/scripts/nbsite_generate_modules.py
@@ -64,7 +64,7 @@ def write_file(name, text, opts):
         print('File %s already exists, skipping.' % fname)
     else:
         print('Creating file %s.' % fname)
-        f = open(fname, 'w')
+        f = open(fname, 'w', encoding='utf-8')
         f.write(text)
         f.close()
 


### PR DESCRIPTION
I tried building hvPlot's website with nbsite on **Windows** and it failed with:

```
  File "C:\hostedtoolcache\windows\Python\3.11.8\x64\Lib\site-packages\docutils\parsers\rst\states.py", line 2104, in directive
    return self.run_directive(
           ^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.11.8\x64\Lib\site-packages\docutils\parsers\rst\states.py", line 2154, in run_directive
    result = directive_instance.run()
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.11.8\x64\Lib\site-packages\nbsite\nbbuild.py", line 467, in run
    evaluate_notebook(
  File "C:\hostedtoolcache\windows\Python\3.11.8\x64\Lib\site-packages\nbsite\nbbuild.py", line 295, in evaluate_notebook
    f.write(newnb)
  File "C:\hostedtoolcache\windows\Python\3.11.8\x64\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u25ba' in position 64474: character maps to <undefined>
```

I ran another pipeline pointing at this branch to confirm it fixes the issue.