### PR TITLE
Add the `sphinxext-rediraffe` extension by default to make it easier to set up redirect links

### DIFF
--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -54,6 +54,7 @@ extensions = [
     'sphinx.ext.linkcode',
     'sphinx.ext.inheritance_diagram',
     'sphinx_copybutton',
+    'sphinxext.rediraffe',
 ]
 
 # Default theme is the PyData Sphinx Theme

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup_args = dict(
         'myst-parser',
         'sphinx-copybutton',
         'sphinx-design',
+        'sphinxext-rediraffe',
         'urllib3 <2.0.0',
     ],
     extras_require= {


### PR DESCRIPTION
I had a good experience using this extension on examples.holoviz.org and would like to make it easier for other projects to use it.