### PR TITLE
Deserialize binary bokeh messages and bump pyodide version

### DIFF
--- a/nbsite/pyodide/WebWorker.js
+++ b/nbsite/pyodide/WebWorker.js
@@ -91,12 +91,15 @@ if msg['mime'] == 'application/bokeh':
     _link_docs_worker(doc, sendPatch, msg['id'], 'js')`
 
 const patch_code = `
-import json
 from panel import state
 
-msg = msg.to_py()
+try:
+    from pane.io.pyodide import _convert_json_patch
+    patch = _convert_json_patch(msg.patch)
+except:
+    patch = msg.patch.to_py()
 doc = state.cache[f"output-{msg['id']}"]
-doc.apply_json_patch(msg['patch'], setter='js')`
+doc.apply_json_patch(patch, setter='js')`
 
 const MESSAGES = {
   patch: patch_code,

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -72,7 +72,7 @@ else:
     bk_prefix = 'release'
 
 DEFAULT_PYODIDE_CONF = {
-    'PYODIDE_URL': 'https://cdn.jsdelivr.net/pyodide/v0.23.1/full/pyodide.js',
+    'PYODIDE_URL': 'https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js',
     'autodetect_deps': True,
     'enable_pwa': True,
     'requirements': ['panel', 'pandas'],


### PR DESCRIPTION
Recent versions of bokeh utilize binary serialization from JS -> Python which means an additional deserialization pass is necessary.