### PR TITLE
Parallelize pyodide based docs

### DIFF
--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -43,13 +43,13 @@ def main(args=None):
 
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))
     build_parser.add_argument('--what',type=str,help='type of output to generate',default='html')
-
     build_parser.add_argument('--project-name', type=str, help='name of project', default='')
     build_parser.add_argument('--org',type=str,help='github organization',default='')
     build_parser.add_argument('--host',type=str,help='host to use when generating notebook links',default='GitHub')
     build_parser.add_argument('--repo',type=str,help='name of repo',default='')
     build_parser.add_argument('--branch',type=str,help='branch to point to in notebook links',default='main')
     build_parser.add_argument('--binder',type=str,help='where to place binder link',choices=['bottom', 'top', 'both', 'none'], default='none')
+    build_parser.add_argument('--disable-parallel',action=argparse.BooleanOptionalAction,help='whether to disable building the docs in parallel')
 
     build_parser.add_argument('--output',type=str,help='where to place output',default="builtdocs")
     _add_common_args(build_parser,'--project-root','--doc','--examples', '--overwrite')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -47,14 +47,6 @@ def fix_links(output, inspect_links):
         args.append( "--inspect-links")
     subprocess.check_call(args)
 
-def _pyodide_enabled(confpy):
-    import runpy
-    current_dir = os.getcwd()
-    os.chdir(os.path.dirname(confpy))
-    file = runpy.run_path(confpy)
-    os.chdir(current_dir)
-    return 'nbsite.pyodide' in file["extensions"]
-
 def build(what='html',
           output='builtdocs',
           project_root='',
@@ -97,11 +89,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    if sys.platform == 'win32' and _pyodide_enabled(os.path.join(paths['doc'], 'conf.py')):
-        # Currently pyodide does not work with -j auto
-        cmd = ["sphinx-build", "-b", what, paths['doc'], output]
-    else:
-        cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
+    cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -101,7 +101,7 @@ def build(what='html',
         # Currently pyodide does not work with -j auto
         cmd = ["sphinx-build", "-b", what, paths['doc'], output]
     else:
-        cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
+        cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -47,14 +47,6 @@ def fix_links(output, inspect_links):
         args.append( "--inspect-links")
     subprocess.check_call(args)
 
-def _pyodide_enabled(confpy):
-    import runpy
-    current_dir = os.getcwd()
-    os.chdir(os.path.dirname(confpy))
-    file = runpy.run_path(confpy)
-    os.chdir(current_dir)
-    return 'nbsite.pyodide' in file["extensions"]
-
 def build(what='html',
           output='builtdocs',
           project_root='',
@@ -75,17 +67,18 @@ def build(what='html',
 
     Usually this is run after `nbsite scaffold`
     """
-    env={'PROJECT_NAME':project_name,
-         'PROJECT_ROOT':project_root if project_root!='' else os.getcwd(),
-         'HOST':host,
-         'REPO':repo,
-         'BRANCH':branch,
-         'ORG':org,
-         'EXAMPLES':examples,
-         'DOC':doc,
-         'EXAMPLES_ASSETS':examples_assets,
-         'BINDER':binder
-         }
+    env = {
+        'PROJECT_NAME':project_name,
+        'PROJECT_ROOT':project_root if project_root!='' else os.getcwd(),
+        'HOST':host,
+        'REPO':repo,
+        'BRANCH':branch,
+        'ORG':org,
+        'EXAMPLES':examples,
+        'DOC':doc,
+        'EXAMPLES_ASSETS':examples_assets,
+        'BINDER':binder
+    }
     merged_env = dict(os.environ, **env)
     none_vals = {k:v for k,v in merged_env.items() if v is None}
     if none_vals:
@@ -96,11 +89,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    if _pyodide_enabled(os.path.join(paths['doc'], 'conf.py')):
-        # Currently pyodide does not work with -j auto
-        cmd = ["sphinx-build", "-b", what, paths['doc'], output]
-    else:
-        cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
+    cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -57,7 +57,7 @@ def build(what='html',
           branch='main',
           org='',
           binder='none',
-          parallel=False,
+          disable_parallel=False,
           examples='examples',
           examples_assets='assets',
           clean_dry_run=False,
@@ -90,7 +90,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    extras = ["-j", "auto"] if parallel else []
+    extras = [] if disable_parallel else ["-j", "auto"]
     cmd = ["sphinx-build", "-b", what, paths['doc'], output] + extras
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -89,7 +89,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    cmd = ["sphinx-build", "-v", "-j", "auto", "-b", what, paths['doc'], output]
+    cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -47,6 +47,14 @@ def fix_links(output, inspect_links):
         args.append( "--inspect-links")
     subprocess.check_call(args)
 
+def _pyodide_enabled(confpy):
+    import runpy
+    current_dir = os.getcwd()
+    os.chdir(os.path.dirname(confpy))
+    file = runpy.run_path(confpy)
+    os.chdir(current_dir)
+    return 'nbsite.pyodide' in file["extensions"]
+
 def build(what='html',
           output='builtdocs',
           project_root='',
@@ -89,7 +97,11 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
+    if sys.platform == 'win32' and _pyodide_enabled(os.path.join(paths['doc'], 'conf.py')):
+        # Currently pyodide does not work with -j auto
+        cmd = ["sphinx-build", "-b", what, paths['doc'], output]
+    else:
+        cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -89,7 +89,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
+    cmd = ["sphinx-build", "-v", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -101,7 +101,7 @@ def build(what='html',
         # Currently pyodide does not work with -j auto
         cmd = ["sphinx-build", "-b", what, paths['doc'], output]
     else:
-        cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
+        cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -89,7 +89,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
+    cmd = ["sphinx-build", "-j", "auto", "-b", what, paths['doc'], output]
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -57,6 +57,7 @@ def build(what='html',
           branch='main',
           org='',
           binder='none',
+          parallel=False,
           examples='examples',
           examples_assets='assets',
           clean_dry_run=False,
@@ -89,7 +90,8 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    cmd = ["sphinx-build", "-vvv", "-j", "auto", "-b", what, paths['doc'], output]
+    extras = ["-j", "auto"] if parallel else []
+    cmd = ["sphinx-build", "-b", what, paths['doc'], output] + extras
     subprocess.check_call(cmd, env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')

--- a/nbsite/pyodide/ServiceWorker.js
+++ b/nbsite/pyodide/ServiceWorker.js
@@ -51,7 +51,9 @@ self.addEventListener('fetch', (e) => {
       throw Error(`[Service Worker] Fetching resource ${e.request.url} failed with response: ${response.status}`);
     }
     console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
-    cache.put(e.request, response.clone());
+    if (e.request.mode !== 'no-cors') {
+      cache.put(e.request, response.clone());
+    }
     return response;
   })());
 });

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -197,7 +197,7 @@ def write_resources(out_dir, source, resources):
     resources: dict[str, any]
         The resources to add to the resource dictionary.
     """
-    out_path = pathlib.Path(str(out_dir))
+    out_path = pathlib.Path(os.fspath(out_dir))
     out_path.mkdir(exist_ok=True)
     resources_file = out_path / RESOURCE_FILE
     existing = resources_file.is_file()

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import sys
+import traceback as tb
 import warnings
 
 from collections import defaultdict
@@ -286,7 +287,10 @@ class PyodideDirective(Directive):
                             mime_type = 'application/bokeh'
                         except Exception:
                             content = None
-                            warnings.warn(f'Could not render {out!r} generated from executed code directive: {code}')
+                            warnings.warn(
+                                f'Could not render {out!r} generated from executed code directive:\n\n{code}\n\n'
+                                f'Failed with following error:\n\n{tb.format_exc()}'
+                            )
                     elif out is not None:
                         try:
                             content, mime_type = format_mime(out)
@@ -568,7 +572,8 @@ def html_page_context(
     # Remove JS files
     pyodide_scripts = (
         app.config.nbsite_pyodide_conf['scripts'] +
-        ['_static/run_cell.js', '_static/WorkerHandler.js']
+        ['_static/run_cell.js', '_static/WorkerHandler.js'] +
+        app.config.html_js_files
     )
 
     context["script_files"] = [

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -297,6 +297,8 @@ class PyodideDirective(Directive):
                         content, mime_type = None, None
                     js, js_exports, js_modules, css, global_exports = extract_extensions(code)
                 pipe.send((content, mime_type, stdout.getvalue(), stderr.getvalue(), js, js_exports, js_modules, css, global_exports))
+            cur_task = asyncio.current_task()
+            await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not cur_task), return_exceptions=True)
         asyncio.get_event_loop().run_until_complete(loop())
         pipe.close()
 

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -285,11 +285,13 @@ class PyodideDirective(Directive):
                             _, content = _model_json(as_panel(out), msg['target'])
                             mime_type = 'application/bokeh'
                         except Exception:
+                            content = None
                             warnings.warn(f'Could not render {out!r} generated from executed code directive: {code}')
                     elif out is not None:
                         try:
                             content, mime_type = format_mime(out)
                         except Exception:
+                            content = None
                             warnings.warn(f'Could not render {out!r} generated from executed code directive: {code}')
                     else:
                         content = None

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -376,7 +376,7 @@ class PyodideDirective(Directive):
                 result = state['cache'][code_hash]
             else:
                 conn.send({'type': 'execute', 'target': f'output-{cellid}', 'code': code})
-                if conn.poll(30):
+                if conn.poll(60):
                     state['cache'][code_hash] = result = conn.recv()
                 else:
                     return [doctree_node]

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -222,6 +222,7 @@ def write_resources(out_dir, source, resources):
             # Add new resources for this source file
             all_resources[source] = source_resources = resources
         json.dump(all_resources, rfile)
+        rfile.flush()
         os.fsync(rfile.fileno())
 
 

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -358,9 +358,7 @@ class PyodideDirective(Directive):
             else:
                 conn.send({'type': 'execute', 'target': f'output-{cellid}', 'code': code})
                 if conn.poll(10):
-                    state['cache'][code_hash] = result = (
-                        conn.recv()
-                    )
+                    state['cache'][code_hash] = result = conn.recv()
                 else:
                     self._kill(current_source)
                     return [doctree_node]

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -278,17 +278,21 @@ class PyodideDirective(Directive):
                         out = exec_with_return(code, stdout=stdout, stderr=stderr)
                     except Exception:
                         out = None
+                    mime_type = None
                     if (isinstance(out, (Model, Viewable, Viewer)) or
                         any(pane.applies(out) for pane in CONVERT_PANE_TYPES)):
-                        _, content = _model_json(as_panel(out), msg['target'])
-                        mime_type = 'application/bokeh'
+                        try:
+                            _, content = _model_json(as_panel(out), msg['target'])
+                            mime_type = 'application/bokeh'
+                        except Exception:
+                            warnings.warn(f'Could not render {out!r} generated from executed code directive: {code}')
                     elif out is not None:
                         try:
                             content, mime_type = format_mime(out)
                         except Exception:
                             warnings.warn(f'Could not render {out!r} generated from executed code directive: {code}')
                     else:
-                        content, mime_type = None, None
+                        content = None
                     js, js_exports, js_modules, css, global_exports = extract_extensions(code)
                 pipe.send((content, mime_type, stdout.getvalue(), stderr.getvalue(), js, js_exports, js_modules, css, global_exports))
             cur_task = asyncio.current_task()

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -8,7 +8,7 @@ import warnings
 
 from collections import defaultdict
 from html import escape
-from multiprocessing import Pipe, Process
+from multiprocessing import Pipe, get_context
 from pathlib import Path
 from typing import (
     Any, Dict, List, Tuple,
@@ -316,7 +316,7 @@ class PyodideDirective(Directive):
         Launches a process to execute code in.
         """
         cls._exec_state[source]['conn'], child_conn = Pipe()
-        cls._exec_state[source]['process'] = process = Process(
+        cls._exec_state[source]['process'] = process = get_context('spawn').Process(
             target=cls._execution_process, args=(child_conn,), daemon=True
         )
         process.start()

--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import io
 import json
+import os
 import pathlib
 import sys
 import warnings
@@ -221,6 +222,8 @@ def write_resources(out_dir, source, resources):
             # Add new resources for this source file
             all_resources[source] = source_resources = resources
         json.dump(all_resources, rfile)
+        os.fsync(rfile.fileno())
+
 
 
 def _option_boolean(arg):

--- a/nbsite/pyodide/_static/run_cell.js
+++ b/nbsite/pyodide/_static/run_cell.js
@@ -92,10 +92,6 @@ let ACCEPTED = false;
 let ADDED = false;
 
 const _addRunButtonToCodeCells = () => {
-  if (ADDED) {
-    return
-  }
-
   // If Pyodide Worker hasn't loaded, wait a bit and try again.
   if (window.pyodideWorker === undefined) {
     setTimeout(addRunButtonToCodeCells, 250)
@@ -113,6 +109,9 @@ const _addRunButtonToCodeCells = () => {
     }
     codeCell.setAttribute('id', id)
     codeCell.setAttribute('executed', false)
+    if (!ADDED) {
+      return
+    }
 
     const RunButton = id =>
     `<button id="button-${id}" class="runbtn o-tooltip--left" data-tooltip="Run cell" data-clipboard-target="#${id}">

--- a/nbsite/pyodide/_static/run_cell.js
+++ b/nbsite/pyodide/_static/run_cell.js
@@ -110,9 +110,13 @@ const _addRunButtonToCodeCells = () => {
     }
     codeCell.setAttribute('id', id)
     codeCell.setAttribute('executed', false)
-    if (!ADDED) {
+
+    // importShim will cause DOMLoaded event to trigger twice so we skip
+    // adding buttons the first time
+    if (!ADDED && window.importShim) {
       return
     }
+    ADDED = true
 
     const RunButton = id =>
     `<button id="button-${id}" class="runbtn o-tooltip--left" data-tooltip="Run cell" data-clipboard-target="#${id}">
@@ -127,8 +131,8 @@ const _addRunButtonToCodeCells = () => {
         ACCEPTED = true
         return
       } else if (!EXECUTED) {
-	Bokeh.index.roots.map((v) => v.remove())
-	EXECUTED = true
+        Bokeh.index.roots.map((v) => v.remove())
+        EXECUTED = true
       }
       let i = 0;
       while (true) {
@@ -140,7 +144,7 @@ const _addRunButtonToCodeCells = () => {
         const output = document.getElementById(`output-${cell_id}`)
         const stdout = document.getElementById(`stdout-${cell_id}`)
         const stderr = document.getElementById(`stderr-${cell_id}`)
-	if (cell.getAttribute('executed') == 'false' || i == index) {
+        if (cell.getAttribute('executed') == 'false' || i == index) {
           if (output) {
             output.innerHTML = '';
             output.style.display = 'none';
@@ -165,7 +169,6 @@ const _addRunButtonToCodeCells = () => {
     run_button.click()
     run_button.click()
   }
-  ADDED = true
 }
 
 _runWhenDOMLoaded(_addRunButtonToCodeCells)

--- a/nbsite/pyodide/_static/run_cell.js
+++ b/nbsite/pyodide/_static/run_cell.js
@@ -89,7 +89,7 @@ const _query_params = new Proxy(new URLSearchParams(window.location.search), {
 });
 
 let ACCEPTED = false;
-let ADDED = false;
+let INITIALIZED = 0;
 let EXECUTED = false;
 
 const _addRunButtonToCodeCells = () => {
@@ -102,6 +102,8 @@ const _addRunButtonToCodeCells = () => {
   // Add copybuttons to all of our code cells
   const RUNBUTTON_SELECTOR = 'div.pyodide div.highlight pre';
   const codeCells = document.querySelectorAll(RUNBUTTON_SELECTOR)
+
+  INITIALIZED += 1
   codeCells.forEach((codeCell, index) => {
     const id = _codeCellId(index)
     const copybtn = codeCell.parentElement.getElementsByClassName('copybtn')
@@ -113,10 +115,9 @@ const _addRunButtonToCodeCells = () => {
 
     // importShim will cause DOMLoaded event to trigger twice so we skip
     // adding buttons the first time
-    if (!ADDED && window.importShim) {
+    if ((INITIALIZED < 2) && window.importShim) {
       return
     }
-    ADDED = true
 
     const RunButton = id =>
     `<button id="button-${id}" class="runbtn o-tooltip--left" data-tooltip="Run cell" data-clipboard-target="#${id}">

--- a/nbsite/pyodide/_static/run_cell.js
+++ b/nbsite/pyodide/_static/run_cell.js
@@ -90,6 +90,7 @@ const _query_params = new Proxy(new URLSearchParams(window.location.search), {
 
 let ACCEPTED = false;
 let ADDED = false;
+let EXECUTED = false;
 
 const _addRunButtonToCodeCells = () => {
   // If Pyodide Worker hasn't loaded, wait a bit and try again.
@@ -125,6 +126,9 @@ const _addRunButtonToCodeCells = () => {
         _ChangeIcon(e.currentTarget, iconAlert)
         ACCEPTED = true
         return
+      } else if (!EXECUTED) {
+	Bokeh.index.roots.map((v) => v.remove())
+	EXECUTED = true
       }
       let i = 0;
       while (true) {
@@ -136,7 +140,7 @@ const _addRunButtonToCodeCells = () => {
         const output = document.getElementById(`output-${cell_id}`)
         const stdout = document.getElementById(`stdout-${cell_id}`)
         const stderr = document.getElementById(`stderr-${cell_id}`)
-        if (cell.getAttribute('executed') == 'false' || i == index) {
+	if (cell.getAttribute('executed') == 'false' || i == index) {
           if (output) {
             output.innerHTML = '';
             output.style.display = 'none';

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup_args = dict(
         'beautifulsoup4',
         'jinja2',
         'pillow',
+        'portalocker',
         'pydata-sphinx-theme >=0.15,<0.16',
         'myst-parser >=3',
         'sphinx-copybutton',


### PR DESCRIPTION
Allows parallelization of pyodide based docs by:

- Storing a state dictionary per document
- Writing resources out to disk (guarded by a lockfile) to ensure we can gather all required resources
- Making the subprocesses daemons