### PR TITLE
Publish nbsite to two new channels: tooling_dev and tooling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,11 +55,11 @@ jobs:
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          doit ecosystem=conda package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev
+          doit ecosystem=conda package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev --label tooling_dev
       - name: conda main upload
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          doit ecosystem=conda package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev --label=main
+          doit ecosystem=conda package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev --label=main --label tooling
   pip_build:
     name: Build PyPI Packages
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
I would like to be able to build hvPlot's docs without any HoloViz dev release but with a dev release of nbsite. This is currently not possible (or at least not easily). With this PR nbsite will get additionally published to `tooling_dev` (dev releases) and `tooling` (main releases) channels.