### PR TITLE
Add `nb_interactivity_warning` extension

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,20 +16,10 @@ on:
 
 jobs:
   pre_commit:
-    name: Run pre-commit hooks
-    runs-on: 'ubuntu-latest'
+    name: Run pre-commit
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "1"
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: pre-commit
-        uses: pre-commit/action@v3.0.0
+      - uses: holoviz-dev/holoviz_tasks/pre-commit@v0
   test_suite:
     name: Test on ${{ matrix.python-version }}, ${{ matrix.os }}
     needs: [pre_commit]

--- a/nbsite/_shared_templates/nb-interactivity-warning.html
+++ b/nbsite/_shared_templates/nb-interactivity-warning.html
@@ -1,4 +1,0 @@
-<div id="scroller-right">
-    This web page was generated from a Jupyter notebook and not all
-    interactivity will work on this website.
-</div>

--- a/nbsite/_shared_templates/nb-interactivity-warning.html
+++ b/nbsite/_shared_templates/nb-interactivity-warning.html
@@ -1,0 +1,4 @@
+<div id="scroller-right">
+    This web page was generated from a Jupyter notebook and not all
+    interactivity will work on this website.
+</div>

--- a/nbsite/nb_interactivity_warning/__init__.py
+++ b/nbsite/nb_interactivity_warning/__init__.py
@@ -36,7 +36,10 @@ def add_interactivity_warning_to_body(
     ):
         if HTML_INTERACTIVITY_WARNING not in context.get('body', ''):
             context['body'] += HTML_INTERACTIVITY_WARNING
-
+            logger.debug(
+                "Adding Notebook interactivity warning to page body as HTML: %s",
+                pagename,
+            )
 
 def setup(app: Sphinx):
     # Event triggered when HTML pages are built

--- a/nbsite/nb_interactivity_warning/__init__.py
+++ b/nbsite/nb_interactivity_warning/__init__.py
@@ -4,7 +4,6 @@ a Jupyter or MyST Markdown notebook, similarly to the warning added by
 the NotebookDirective.
 
 This extension depends on:
-- nbsite/_shared_templates/nb-interactivity-warning.html
 - nbsite/_shared_static/scroller.css (also needed for the NotebookDirective)
 """
 
@@ -16,38 +15,32 @@ from .. import __version__ as nbs_version
 logger = getLogger(__name__)
 
 
-def add_sidebar_content(
+HTML_INTERACTIVITY_WARNING = """
+<div id="scroller-right">
+    This web page was generated from a Jupyter notebook and not all
+    interactivity will work on this website.
+</div>
+"""
+
+
+def add_interactivity_warning_to_body(
     app: Sphinx, pagename: str, templatename: str, context: dict, doctree
 ):
     """
-    Adds custom content to the right sidebar if the page is a Jupyter Notebook.
+    Adds custom content to context body if the page is a Jupyter Notebook.
     """
     if context.get("page_source_suffix") == ".ipynb" or (
         context.get("page_source_suffix") == ".md"
         # There might be other ways to find this out, seems to work.
         and "kernelspec" in app.env.metadata[pagename]
     ):
-        sidebar_items = context.get("theme_secondary_sidebar_items", [])
-        if "nb-interactivity-warning" in sidebar_items:
-            return
-        # theme_secondary_sidebar_items can be a list or a comma-separated string.
-        if isinstance(sidebar_items, str):
-            if sidebar_items:
-                sidebar_items = ", ".join([sidebar_items, "nb-interactivity-warning"])
-            else:
-                sidebar_items = "nb-interactibity-warning"
-        else:
-            sidebar_items.append("nb-interactivity-warning")
-        context["theme_secondary_sidebar_items"] = sidebar_items
-        logger.debug(
-            "Adding 'nb-interactivity-warning' item to the secondary sidebar: %s",
-            pagename,
-        )
+        if HTML_INTERACTIVITY_WARNING not in context.get('body', ''):
+            context['body'] += HTML_INTERACTIVITY_WARNING
 
 
 def setup(app: Sphinx):
     # Event triggered when HTML pages are built
-    app.connect("html-page-context", add_sidebar_content)
+    app.connect("html-page-context", add_interactivity_warning_to_body)
     return {
         "version": nbs_version,
         "parallel_read_safe": True,

--- a/nbsite/nb_interactivity_warning/__init__.py
+++ b/nbsite/nb_interactivity_warning/__init__.py
@@ -1,0 +1,57 @@
+"""
+nb_interactivity_warning extension adds a warning box to pages built from
+a Jupyter or MyST Markdown notebook, similarly to the warning added by
+the NotebookDirective.
+
+This extension depends on:
+- nbsite/_shared_templates/nb-interactivity-warning.html
+- nbsite/_shared_static/scroller.css (also needed for the NotebookDirective)
+"""
+
+from sphinx.application import Sphinx
+from sphinx.util.logging import getLogger
+
+from .. import __version__ as nbs_version
+
+logger = getLogger(__name__)
+
+
+def add_sidebar_content(
+    app: Sphinx, pagename: str, templatename: str, context: dict, doctree
+):
+    """
+    Adds custom content to the right sidebar if the page is a Jupyter Notebook.
+    """
+    print("XXX", pagename, context.get("page_source_suffix") )
+    if context.get("page_source_suffix") == ".ipynb" or (
+        context.get("page_source_suffix") == ".md"
+        # There might be other ways to find this out, seems to work.
+        and "kernelspec" in app.env.metadata[pagename]
+    ):
+        sidebar_items = context.get("theme_secondary_sidebar_items", [])
+        if "nb-interactivity-warning" in sidebar_items:
+            return
+        # theme_secondary_sidebar_items can be a list or a comma-separated string.
+        if isinstance(sidebar_items, str):
+            if sidebar_items:
+                sidebar_items = ", ".join([sidebar_items, "nb-interactivity-warning"])
+            else:
+                sidebar_items = "nb-interactibity-warning"
+        else:
+            sidebar_items.append("nb-interactivity-warning")
+        context["theme_secondary_sidebar_items"] = sidebar_items
+        print("YYY", context["theme_secondary_sidebar_items"])
+        logger.debug(
+            "Adding 'nb-interactivity-warning' item to the secondary sidebar: %s",
+            pagename,
+        )
+
+
+def setup(app: Sphinx):
+    # Event triggered when HTML pages are built
+    app.connect("html-page-context", add_sidebar_content)
+    return {
+        "version": nbs_version,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/nbsite/nb_interactivity_warning/__init__.py
+++ b/nbsite/nb_interactivity_warning/__init__.py
@@ -22,7 +22,6 @@ def add_sidebar_content(
     """
     Adds custom content to the right sidebar if the page is a Jupyter Notebook.
     """
-    print("XXX", pagename, context.get("page_source_suffix") )
     if context.get("page_source_suffix") == ".ipynb" or (
         context.get("page_source_suffix") == ".md"
         # There might be other ways to find this out, seems to work.
@@ -40,7 +39,6 @@ def add_sidebar_content(
         else:
             sidebar_items.append("nb-interactivity-warning")
         context["theme_secondary_sidebar_items"] = sidebar_items
-        print("YYY", context["theme_secondary_sidebar_items"])
         logger.debug(
             "Adding 'nb-interactivity-warning' item to the secondary sidebar: %s",
             pagename,

--- a/site/doc/conf.py
+++ b/site/doc/conf.py
@@ -22,6 +22,8 @@ extensions += [
     'nbsite.gallery',
     # To setup GoatCounter
     'nbsite.analytics',
+    # To add an interactive warning on pages built from a notebook.
+    'nbsite.nb_interactivity_warning',
     # Activate the docstring extension for Numpy: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
     'sphinx.ext.napoleon',
     # See https://github.com/ipython/ipython/issues/13845

--- a/site/doc/user_guide/extra_extensions.md
+++ b/site/doc/user_guide/extra_extensions.md
@@ -1,0 +1,7 @@
+## Sphinx extensions
+
+`nbsite` ships some additional Sphinx extensions.
+
+## `nb_interactivity_warning`
+
+Enabling this extension will add an interactivity warning (similarly to the one added by the `NotebookDirective`) to pages built from Jupyter or MyST Markdown notebooks.

--- a/site/doc/user_guide/index.md
+++ b/site/doc/user_guide/index.md
@@ -8,4 +8,5 @@
 Usage <usage>
 Gallery <gallery>
 Param reference <param_doc>
+Extra extensions <extra_extension>
 ```


### PR DESCRIPTION
Some websites using nbsite (e.g. hvplot, param) no longer use the `NotebookDirective` to build Jupyter Notebooks and MyST Markdown notebooks, instead, they're built directly with MyST-MB. Consequently, the pages built this way don't have the interactivity warning that lets users know some interactivity may not work on the website. This PR adds an extension that adds this warning to these pages.

Example:
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/b91b9fbe-ede5-4be8-9178-36bcece06ca1">
