### PR TITLE
fix: Don't lock when generators are used

### DIFF
--- a/nbsite/pyodide/__init__.py
+++ b/nbsite/pyodide/__init__.py
@@ -301,11 +301,12 @@ class PyodideDirective(Directive):
                         content = None
                     js, js_exports, js_modules, css, global_exports = extract_extensions(code)
                 pipe.send((content, mime_type, stdout.getvalue(), stderr.getvalue(), js, js_exports, js_modules, css, global_exports))
-            loop = asyncio.get_running_loop()
-            await loop.shutdown_asyncgens()
-            await loop.shutdown_default_executor()
-            cur_task = asyncio.current_task()
-            await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not cur_task), return_exceptions=True)
+
+            tasks = asyncio.all_tasks() - {asyncio.current_task()}
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         asyncio.get_event_loop().run_until_complete(event_loop())
         pipe.close()
 


### PR DESCRIPTION
Pushing to main will make this hard to track. 

See: 
https://github.com/holoviz-dev/nbsite/commit/6b4ff30aca4ee3d657ddf0ecdf52f555a33d24be
https://github.com/holoviz-dev/nbsite/commit/bec1c0e4fcea29a27545215a6db32bfa122492c7