### PR TITLE
Gallery thumbnails: make HoloViews and Matplotlib optional

### DIFF
--- a/nbsite/gallery/thumbnailer.py
+++ b/nbsite/gallery/thumbnailer.py
@@ -6,8 +6,6 @@ import subprocess
 import sys
 import tempfile
 
-import matplotlib.pyplot as plt
-
 from holoviews.core import Dimensioned, Store
 from holoviews.ipython.preprocessors import (
     OptsMagicProcessor, OutputMagicProcessor, StripMagicsProcessor,
@@ -15,7 +13,11 @@ from holoviews.ipython.preprocessors import (
 from holoviews.util.command import export_to_python
 from nbconvert.preprocessors import Preprocessor
 
-plt.switch_backend('agg')
+try:
+    import matplotlib.pyplot as plt
+    plt.switch_backend('agg')
+except ModuleNotFoundError:
+    pass
 
 def comment_out_magics(source):
     """

--- a/nbsite/ipystartup.py
+++ b/nbsite/ipystartup.py
@@ -2,9 +2,11 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
-import matplotlib as mpl
-
-mpl.use('agg')
+try:
+    import matplotlib as mpl
+    mpl.use('agg')
+except ModuleNotFoundError:
+    pass
 
 try:
     import holoviews.plotting.bokeh  # noqa


### PR DESCRIPTION
I'm setting up the docs for panel-material-ui and saw matplotlib and holoviews are required by default to build the gallery, except that I believe they're just used to automatically build the thumbnails.