### PR TITLE
linkcode: fix importing some packages

### DIFF
--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -180,9 +180,14 @@ def linkcode_resolve(domain, info):
     linespec = f"#L{lineno}-L{lineno + len(source) - 1}" if lineno else ""
 
     package = get_repo_dir()
+    package = package.lower().replace('-', '_')
+    try:
+        top_module = importlib.__import__(package)
+    except ModuleNotFoundError:
+        return
 
-    ppath = importlib.__import__(package).__file__
-    pver = importlib.__import__(package).__version__
+    ppath = top_module.__file__
+    pver = top_module.__version__
 
     fn = os.path.relpath(fn, start=os.path.dirname(ppath))
 


### PR DESCRIPTION
Bug found when building `panel-material-ui`. `get_repo_dir()` returns it as a string and obviously this can't be imported. I've added some normalization and a try/except. Pretty sure there's a better way, but that will unblock us and should cover most cases.