### PR TITLE
Enable per-page interactivity warning

### DIFF
--- a/nbsite/nb_interactivity_warning/__init__.py
+++ b/nbsite/nb_interactivity_warning/__init__.py
@@ -3,6 +3,12 @@ nb_interactivity_warning extension adds a warning box to pages built from
 a Jupyter or MyST Markdown notebook, similarly to the warning added by
 the NotebookDirective.
 
+It is enabled by default and can be configured with:
+- `nb_interactivity_warning_enable = False`, to disable it
+- `nb_interactivity_warning_per_file = True` and adding the tag
+  `nb-interactivity-warning` to the notebook metadata, to enable it only
+  on specific pages
+
 This extension depends on:
 - nbsite/_shared_static/scroller.css (also needed for the NotebookDirective)
 """
@@ -29,11 +35,20 @@ def add_interactivity_warning_to_body(
     """
     Adds custom content to context body if the page is a Jupyter Notebook.
     """
+    if not app.config.nb_interactivity_warning_enable:
+        return
+
     if context.get("page_source_suffix") == ".ipynb" or (
         context.get("page_source_suffix") == ".md"
         # There might be other ways to find this out, seems to work.
         and "kernelspec" in app.env.metadata[pagename]
     ):
+        # When per-file warning is enabled, ignore files that don't have the tag.
+        if app.config.nb_interactivity_warning_per_file:
+            per_page_metadata = app.env.metadata.get(pagename, {})
+            if "nb-interactivity-warning" not in per_page_metadata.get("tags", []):
+                return
+
         if HTML_INTERACTIVITY_WARNING not in context.get('body', ''):
             context['body'] += HTML_INTERACTIVITY_WARNING
             logger.debug(
@@ -42,6 +57,8 @@ def add_interactivity_warning_to_body(
             )
 
 def setup(app: Sphinx):
+    app.add_config_value("nb_interactivity_warning_enable", True, "html")
+    app.add_config_value("nb_interactivity_warning_per_file", False, "html")
     # Event triggered when HTML pages are built
     app.connect("html-page-context", add_interactivity_warning_to_body)
     return {

--- a/site/doc/conf.py
+++ b/site/doc/conf.py
@@ -104,3 +104,5 @@ html_css_files += [
 
 # Override the Sphinx default title that appends `documentation`
 html_title = f'{project} v{version}'
+
+nb_interactivity_warning_per_file = True

--- a/site/doc/playground/mystmdnb/holoviz.md
+++ b/site/doc/playground/mystmdnb/holoviz.md
@@ -7,6 +7,8 @@ jupytext:
 kernelspec:
   display_name: Python 3
   name: python3
+tags:
+  - nb-interactivity-warning
 ---
 
 # HoloViz outputs

--- a/site/doc/playground/mystnb/holoviz.ipynb
+++ b/site/doc/playground/mystnb/holoviz.ipynb
@@ -92,7 +92,10 @@
   "language_info": {
    "name": "python",
    "pygments_lexer": "ipython3"
-  }
+  },
+  "tags": [
+    "nb-interactivity-warning"
+  ]
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/site/doc/user_guide/extra_extensions.md
+++ b/site/doc/user_guide/extra_extensions.md
@@ -5,3 +5,9 @@
 ## `nb_interactivity_warning`
 
 Enabling this extension will add an interactivity warning (similarly to the one added by the `NotebookDirective`) to pages built from Jupyter or MyST Markdown notebooks.
+
+It is enabled by default and can be configured with:
+- `nb_interactivity_warning_enable = False`, to disable it
+- `nb_interactivity_warning_per_file = True` and adding the tag
+  `nb-interactivity-warning` to the notebook metadata, to enable it only
+  on specific pages


### PR DESCRIPTION
As not all the hvPlot pages require the interactivity warning.