### PR TITLE
Add validate_versioned extension

### DIFF
--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -37,6 +37,8 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx_copybutton',
     'sphinxext.rediraffe',
+    # To validate the configuration of versioned sites
+    'nbsite.validate_versioned',
 ]
 
 # Default theme is the PyData Sphinx Theme

--- a/nbsite/validate_versioned/404.html
+++ b/nbsite/validate_versioned/404.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Page Not Found</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #333;
+            line-height: 1.6;
+        }
+        .container {
+            background: white;
+            padding: 3rem;
+            border-radius: 10px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 500px;
+            width: 90%;
+            animation: fadeIn 0.5s ease-out;
+        }
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+                transform: translateY(20px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+        .error-code {
+            font-size: 6rem;
+            font-weight: 700;
+            background: linear-gradient(45deg, #667eea 0%, #764ba2 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 0.5rem;
+            animation: pulse 2s ease-in-out infinite;
+        }
+        @keyframes pulse {
+            0%, 100% {
+                transform: scale(1);
+            }
+            50% {
+                transform: scale(1.05);
+            }
+        }
+        h1 {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            color: #444;
+        }
+        p {
+            color: #666;
+            margin-bottom: 2rem;
+        }
+        .links {
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+        a {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            text-decoration: none;
+            border-radius: 5px;
+            transition: all 0.3s ease;
+            font-weight: 500;
+        }
+        .btn-primary {
+            background: linear-gradient(45deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+        }
+        .btn-secondary {
+            background: #f0f0f0;
+            color: #666;
+        }
+        .btn-secondary:hover {
+            background: #e0e0e0;
+            color: #333;
+        }
+        @media (max-width: 480px) {
+            .container {
+                padding: 2rem;
+            }
+            .error-code {
+                font-size: 4rem;
+            }
+            h1 {
+                font-size: 1.25rem;
+            }
+            .links {
+                flex-direction: column;
+                width: 100%;
+            }
+            a {
+                width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="error-code">404</div>
+        <h1>Page Not Found</h1>
+        <p>
+            Sorry, we couldn't find the page you're looking for.
+            It might have been moved, deleted, or never existed.
+        </p>
+        <div class="links">
+            <a href="/" class="btn-primary">Go Home</a>
+            <a href="/en/docs/latest/" class="btn-secondary">Documentation</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/nbsite/validate_versioned/__init__.py
+++ b/nbsite/validate_versioned/__init__.py
@@ -1,0 +1,30 @@
+"""
+validate_versioned extension validates the configuration of versioned sites.
+"""
+
+
+from sphinx.util import logging
+
+from .. import __version__ as nbs_version
+
+logger = logging.getLogger(__name__)
+
+def check_for_switcher_key(app):
+    theme_opts = app.config.html_theme_options
+    if (
+        isinstance(theme_opts, dict)
+        and 'switcher' in theme_opts
+        and not app.config.html_baseurl
+    ):
+        logger.warning(
+            "html_baseurl must be set when the site is versioned. For example: "
+            "`html_baseurl = 'https://hvplot.holoviz.org/en/docs/latest/'`"
+        )
+
+def setup(app):
+    app.connect('builder-inited', check_for_switcher_key)
+    return {
+        "version": nbs_version,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/nbsite/validate_versioned/__init__.py
+++ b/nbsite/validate_versioned/__init__.py
@@ -7,6 +7,7 @@ validate_versioned extension to support versioned sites.
 """
 import itertools
 import json
+import shutil
 import xml.etree.ElementTree as ET
 
 from pathlib import Path
@@ -34,7 +35,7 @@ def check_for_html_baseurl(app):
     <link rel="canonical" href="<html_baseurl>/<path/to/page.html>" />
     Useful for SEO purposes.
     """
-    if  not app.config.html_baseurl:
+    if not app.config.html_baseurl:
         logger.warning(
             "html_baseurl must be set when the site is versioned. For example: "
             "`html_baseurl = 'https://hvplot.holoviz.org/en/docs/latest/'`"
@@ -175,6 +176,16 @@ def build_robots(app, our_dir):
     logger.info(f"robots.txt written at {out_path}")
 
 
+def build_404(out_dir):
+    file_404 = Path(__file__).parent / "404.html"
+    if not file_404.exists():
+        logger.warning("Missing 404.html file")
+        return
+    out_path = out_dir / "404.html"
+    shutil.copyfile(file_404, out_path)
+    logger.info(f"robots.txt written at {out_path}")
+
+
 def validate_versioned(app, exc):
     if not app.config.validate_versioned:
         return
@@ -193,6 +204,7 @@ def validate_versioned(app, exc):
     out_dir.mkdir(parents=True, exist_ok=True)
     build_sitemap(app, out_dir)
     build_robots(app, out_dir)
+    build_404(out_dir)
     (out_dir / ".gitignore").write_text("*")
 
 

--- a/nbsite/validate_versioned/__init__.py
+++ b/nbsite/validate_versioned/__init__.py
@@ -1,8 +1,13 @@
 """
 validate_versioned extension validates the configuration of versioned sites.
 """
+import itertools
+import json
+import xml.etree.ElementTree as ET
 
+from pathlib import Path
 
+from packaging import version
 from sphinx.util import logging
 
 from .. import __version__ as nbs_version
@@ -21,8 +26,117 @@ def check_for_switcher_key(app):
             "`html_baseurl = 'https://hvplot.holoviz.org/en/docs/latest/'`"
         )
 
+def priorities_generator():
+    """
+    Generator returning ``priority`` needed by sitemap.xml.
+
+    It generates values from 1 to 0.1 by decreasing in 0.1 on each
+    iteration. After 0.1 is reached, it will keep returning 0.1.
+
+    Copied from readthedocs
+    """
+    priorities = [1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2]
+    yield from itertools.chain(priorities, itertools.repeat(0.1))
+
+
+def changefreqs_generator():
+    """
+    Generator returning ``changefreq`` needed by sitemap.xml.
+
+    It returns ``weekly`` on first iteration, ~~then ``daily`` and~~, then it
+    will return always ``monthly``.
+
+    Note: readthedocs uses `daily` for /latest which corresponds to the
+    dev version. We prefer not to reference the dev version at all.
+
+    We are using ``monthly`` as last value because ``never`` is too
+    aggressive. If the tag is removed and a branch is created with the same
+    name, we will want bots to revisit this.
+
+    Copied and adapted from readthedocs
+    """
+    # changefreqs = ["weekly", "daily"]
+    changefreqs = ["weekly"]
+    yield from itertools.chain(changefreqs, itertools.repeat("monthly"))
+
+
+def indent_xml(elem, level=0):
+    i = "\n" + level * "  "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "  "
+        for child in elem:
+            indent_xml(child, level + 1)
+        if not elem[-1].tail or not elem[-1].tail.strip():
+            elem[-1].tail = i
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+
+
+def build_sitemap(app):
+    """
+    Build a sitemap.xml file, inspired by readthedocs.
+
+    Uses the data in switcher.json. Output file is saved next to
+    conf.py.
+
+    Does not include the dev version.
+    """
+    theme_opts = app.config.html_theme_options
+    if (
+        isinstance(theme_opts, dict)
+        and 'switcher' not in app.config.html_theme_options
+    ):
+        return
+    confdir = Path(app.confdir)
+    switcher_path = confdir / '_static' / 'switcher.json'
+    if not switcher_path.exists():
+        logger.warning(
+            "switcher.json not found in _static directory, sitemap.xml "
+            "cannot be built."
+        )
+        return
+
+    with open(switcher_path) as f:
+        switcher_data = json.load(f)
+
+    switcher_data =  [data for data in switcher_data if data.get('version') != 'dev']
+    switcher_data = sorted(
+        switcher_data,
+        key=lambda el: version.parse(el['version']),
+        reverse=True,
+    )
+
+    versions = []
+    for data, priority, changefreq in zip(switcher_data, priorities_generator(), changefreqs_generator()):
+        element = {
+            'loc': data['url'],
+            # 'lastmod': '?',
+            'changefreq': changefreq,
+            'priority': priority,
+        }
+        versions.append(element)
+
+    urlset = ET.Element("urlset", xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
+
+    for entry in versions:
+        url = ET.SubElement(urlset, "url")
+        ET.SubElement(url, "loc").text = entry["loc"]
+        # ET.SubElement(url, "lastmod").text = "?"
+        ET.SubElement(url, "changefreq").text = entry["changefreq"]
+        ET.SubElement(url, "priority").text = str(entry["priority"])
+
+    indent_xml(urlset)
+    tree = ET.ElementTree(urlset)
+    tree.write(confdir / "sitemap.xml", encoding="utf-8", xml_declaration=True)
+
+
 def setup(app):
     app.connect('builder-inited', check_for_switcher_key)
+    app.connect('builder-inited', build_sitemap)
     return {
         "version": nbs_version,
         "parallel_read_safe": True,

--- a/nbsite/validate_versioned/check_links.py
+++ b/nbsite/validate_versioned/check_links.py
@@ -220,7 +220,7 @@ class SiteValidator:
         paths = ["/bad/", "/bad", "/bad.html", "/bad.xyz"]
 
         for path in paths:
-            self.check_response(path, 404, "File not found")
+            self.check_response(path, 404, "Sorry, we couldn't find the page you're looking for")
 
     def run_all_tests(self):
         """Run all standard tests."""

--- a/nbsite/validate_versioned/check_links.py
+++ b/nbsite/validate_versioned/check_links.py
@@ -1,0 +1,305 @@
+"""
+Script to check that a site that went through a migration from
+Github Pages to being versioned (PyData Sphinx Theme version switcher
++ CloudFront + S3) has its links working as expected.
+"""
+import argparse
+import sys
+
+import requests
+
+EPILOG = """
+Examples:
+  # Test standard site with specific version
+  %(prog)s test --base-url https://hvplot-test.holoviz.org --version 0.11.3
+
+  # Run tests with verbose output
+  %(prog)s test --base-url https://example.com --version 1.0.0 --verbose
+
+  # Test GitHub Pages only with default URL
+  %(prog)s github-pages
+"""
+
+DEFAULT_GITHUB_PAGES_URL = "https://holoviz.org/"
+
+
+class SiteValidator:
+    def __init__(self, base_url: str, version: str | None = None, verbose: bool = False):
+        self.base_url = base_url.rstrip('/')
+        self.version = version
+        self.verbose = verbose
+        self.failed_tests = []
+        self.passed_tests = 0
+
+    def log(self, message: str):
+        """Print message if verbose mode is enabled."""
+        if self.verbose:
+            print(message)
+
+    def check_redirect(self, path: str, expected_status: int, expected_location: str | None = None) -> bool:
+        """Check if a path redirects as expected."""
+        resp = requests.head(self.base_url + path, allow_redirects=False, timeout=10)
+
+        # Check status code
+        if resp.status_code != expected_status:
+            self.failed_tests.append({
+                'path': path,
+                'error': f"Expected status {expected_status}, got {resp.status_code}",
+                'response': resp
+            })
+            return False
+
+        # Check location header if expected
+        if expected_location and resp.headers.get('Location') != expected_location:
+            self.failed_tests.append({
+                'path': path,
+                'error': f"Expected location '{expected_location}', got '{resp.headers.get('Location')}'",
+                'response': resp
+            })
+            return False
+
+        self.passed_tests += 1
+        self.log(f"✓ {path} -> {expected_status} {expected_location or ''}")
+        return True
+
+    def check_response(self, path: str, expected_status: int, expected_content: str | None = None) -> bool:
+        """Check if a path returns expected response."""
+        resp = requests.get(self.base_url + path, allow_redirects=False, timeout=10)
+
+        # Check status code
+        if resp.status_code != expected_status:
+            self.failed_tests.append({
+                'path': path,
+                'error': f"Expected status {expected_status}, got {resp.status_code}",
+                'response': resp
+            })
+            return False
+
+        # Check content if expected
+        if expected_content and expected_content not in resp.text:
+            self.failed_tests.append({
+                'path': path,
+                'error': f"Expected content '{expected_content}' not found",
+                'response': resp
+            })
+            return False
+
+        self.passed_tests += 1
+        self.log(f"✓ {path} -> {expected_status}")
+        return True
+
+    def test_redirects_root_to_docs_latest(self):
+        """Test redirects from root to /en/docs/latest/"""
+        print("\n=== Testing root redirects to /en/docs/latest/ ===")
+        paths = ["", "/", "/index.html", "/docs", "/docs/", "/en/docs", "/en/docs/"]
+
+        for path in paths:
+            self.check_redirect(path, 301, '/en/docs/latest/')
+
+    def test_redirects_to_docs_latest(self):
+        """Test redirects that add trailing slash."""
+        print("\n=== Testing redirects that add trailing slash ===")
+        paths = [
+            "/en/docs/latest",
+            "/en/docs/dev",
+            f"/en/docs/{self.version}",
+            "/en/docs/latest?key=value",
+            "/en/docs/dev?key=value",
+            f"/en/docs/{self.version}?key=value",
+        ]
+
+        for path in paths:
+            if "?" in path:
+                expected = path.replace("?", "/?")
+            else:
+                expected = path + "/"
+            self.check_redirect(path, 301, expected)
+
+    def test_old_to_new_redirects(self):
+        """Test old URL pattern redirects to new pattern."""
+        print("\n=== Testing old to new URL redirects ===")
+        paths = ["/user_guide", "/user_guide?key=value"]
+
+        for path in paths:
+            if "?" in path:
+                expected = "/en/docs/latest" + path.replace("?", "/?")
+            else:
+                expected = "/en/docs/latest" + path + "/"
+            self.check_redirect(path, 301, expected)
+
+    def test_pages_with_index(self):
+        """Test pages that end with /index return 200."""
+        print("\n=== Testing pages ending with /index ===")
+        paths = ["/en/docs/latest/index", "/en/docs/latest/user_guide/index"]
+
+        for path in paths:
+            self.check_response(path, 200)
+
+    def test_pages_with_slash(self):
+        """Test pages that end with slash return 200."""
+        print("\n=== Testing pages ending with slash ===")
+        paths = ["/en/docs/latest/user_guide/"]
+
+        for path in paths:
+            self.check_response(path, 200)
+
+    def test_file_urls_old_to_new(self):
+        """Test file URLs old pattern redirects."""
+        print("\n=== Testing pretty URLs old to new redirects ===")
+        paths = ["/user_guide/Introduction.html", "/user_guide/Introduction.html?key=value"]
+
+        for path in paths:
+            expected = "/en/docs/latest" + path
+            self.check_redirect(path, 301, expected)
+
+    def test_pretty_urls_old_to_new(self):
+        """Test pretty URLs old pattern redirects."""
+        print("\n=== Testing pretty URLs old to new redirects ===")
+        paths = ["/user_guide/Introduction", "/user_guide/Introduction?key=value"]
+
+        for path in paths:
+            if "?" in path:
+                expected = "/en/docs/latest" + path.replace("?", ".html?")
+            else:
+                expected = "/en/docs/latest" + path + ".html"
+            self.check_redirect(path, 301, expected)
+
+    def test_pretty_urls(self):
+        """Test pretty URLs return 200."""
+        print("\n=== Testing pretty URLs ===")
+        paths = [
+            "/en/docs/latest/user_guide/Introduction",
+            "/en/docs/latest/user_guide/Introduction?key=value"
+        ]
+
+        for path in paths:
+            self.check_response(path, 200)
+
+    def test_directories(self):
+        """Test directory redirects."""
+        print("\n=== Testing directory redirects ===")
+        paths = [
+            "/user_guide",
+            "/en/docs/latest/user_guide",
+            "/user_guide?key=value",
+            "/en/docs/latest/user_guide?key=value",
+        ]
+
+        for path in paths:
+            if "?" in path:
+                expected = path.replace("?", "/?")
+            else:
+                expected = path + "/"
+            if "/en/docs" not in expected:
+                expected = "/en/docs/latest" + expected
+            self.check_redirect(path, 301, expected)
+
+    def test_github_pages_pretty_urls(self):
+        """Test GitHub Pages specific pretty URLs."""
+        print("\n=== Testing GitHub Pages pretty URLs ===")
+        paths = ["/about/heps/hep0", "/about/heps/hep0?key=value"]  # codespell:ignore heps
+
+        for path in paths:
+            self.check_response(path, 200)
+
+    def test_github_pages_directories(self):
+        """Test GitHub Pages specific directory redirects."""
+        print("\n=== Testing GitHub Pages directory redirects ===")
+        paths = ["/about", "/about?key=value"]
+
+        for path in paths:
+            if "?" in path:
+                expected = self.base_url + path.replace("?", "/?")
+            else:
+                expected = self.base_url + path + "/"
+            self.check_redirect(path, 301, expected)
+
+    def test_404_pages(self):
+        """Test 404 pages."""
+        print("\n=== Testing 404 pages ===")
+        paths = ["/bad/", "/bad", "/bad.html", "/bad.xyz"]
+
+        for path in paths:
+            self.check_response(path, 404, "File not found")
+
+    def run_all_tests(self):
+        """Run all standard tests."""
+        self.test_redirects_root_to_docs_latest()
+        self.test_redirects_to_docs_latest()
+        self.test_old_to_new_redirects()
+        self.test_file_urls_old_to_new()
+        self.test_pages_with_index()
+        self.test_pages_with_slash()
+        self.test_pretty_urls_old_to_new()
+        self.test_pretty_urls()
+        self.test_directories()
+
+    def run_github_pages_tests(self):
+        """Run GitHub Pages specific tests."""
+        self.test_github_pages_pretty_urls()
+        self.test_github_pages_directories()
+        self.test_404_pages()
+
+    def print_summary(self):
+        """Print test summary."""
+        print(f"\n{'='*60}")
+        print(f"TEST SUMMARY: {self.passed_tests} passed, {len(self.failed_tests)} failed")
+        print(f"{'='*60}")
+
+        if self.failed_tests:
+            print("\nFAILED TESTS:")
+            for test in self.failed_tests:
+                print(f"\n❌ Path: {test['path']}")
+                print(f"   Error: {test['error']}")
+                if test['response']:
+                    print(f"   Status: {test['response'].status_code}")
+                    if 'Location' in test['response'].headers:
+                        print(f"   Location: {test['response'].headers['Location']}")
+                    if len(test['response'].text) < 200:
+                        print(f"   Response: {test['response'].text[:200]}")
+                    else:
+                        print(f"   Response (truncated): {test['response'].text[:200]}...")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate site URLs and redirects",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=EPILOG,
+    )
+
+    subparsers = parser.add_subparsers(dest='command', help='Command to run')
+
+    # Main test command
+    test_parser = subparsers.add_parser('test', help='Run all validation tests')
+    test_parser.add_argument('--base-url', required=True, help='Base URL of the site to test')
+    test_parser.add_argument('--version', required=True, help='Specific version to test (e.g., 0.11.3)')
+    test_parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
+
+    # GitHub Pages test command
+    github_parser = subparsers.add_parser('github-pages', help='Run GitHub Pages specific tests')
+    github_parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.command == 'test':
+        validator = SiteValidator(args.base_url, args.version, args.verbose)
+        print(f"Running validation tests for {args.base_url} (version: {args.version})")
+        validator.run_all_tests()
+        validator.print_summary()
+        sys.exit(1 if validator.failed_tests else 0)
+
+    elif args.command == 'github-pages':
+        validator = SiteValidator(DEFAULT_GITHUB_PAGES_URL, verbose=args.verbose)
+        print(f"Running GitHub Pages tests for {DEFAULT_GITHUB_PAGES_URL}")
+        validator.run_github_pages_tests()
+        validator.print_summary()
+        sys.exit(1 if validator.failed_tests else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi.toml
+++ b/pixi.toml
@@ -59,6 +59,7 @@ pip = "*"
 portalocker = "*"
 pydata-sphinx-theme = '>=0.15,<0.17'
 pyviz_comms = "*"
+requests = "*"
 sphinx = '>=7'
 sphinx-copybutton = "*"
 sphinx-design = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dependencies = [
     'sphinx-copybutton',
     'sphinx-design',
     'sphinxext-rediraffe',
-    'packaging'
+    'packaging',
+    'requests'
 ]
 
 [project.scripts]

--- a/site/doc/conf.py
+++ b/site/doc/conf.py
@@ -106,3 +106,5 @@ html_css_files += [
 html_title = f'{project} v{version}'
 
 nb_interactivity_warning_per_file = True
+
+nb_execution_mode = "off"

--- a/site/doc/conf.py
+++ b/site/doc/conf.py
@@ -107,4 +107,5 @@ html_title = f'{project} v{version}'
 
 nb_interactivity_warning_per_file = True
 
-nb_execution_mode = "off"
+# Disable notebook execution
+# nb_execution_mode = "off"

--- a/site/doc/user_guide/extra_extensions.md
+++ b/site/doc/user_guide/extra_extensions.md
@@ -15,4 +15,8 @@ It is enabled by default and can be configured with:
 
 ## `validate_versioned`
 
-Adding this extension will validate the configuration of versioned sites.
+Adding this extension is helpful to support versioned sites:
+
+- Checks html_baseurl is set
+- Creates a sitemap.xml file in the conf dir
+- Checks a robots.txt file is available

--- a/site/doc/user_guide/extra_extensions.md
+++ b/site/doc/user_guide/extra_extensions.md
@@ -11,3 +11,8 @@ It is enabled by default and can be configured with:
 - `nb_interactivity_warning_per_file = True` and adding the tag
   `nb-interactivity-warning` to the notebook metadata, to enable it only
   on specific pages
+
+
+## `validate_versioned`
+
+Adding this extension will validate the configuration of versioned sites.

--- a/site/doc/user_guide/extra_extensions.md
+++ b/site/doc/user_guide/extra_extensions.md
@@ -18,5 +18,5 @@ It is enabled by default and can be configured with:
 Adding this extension is helpful to support versioned sites:
 
 - Checks html_baseurl is set
-- Creates a sitemap.xml file in the conf dir
-- Checks a robots.txt file is available
+- Creates a sitemap.xml file in a subdirectory of the docs source
+- Creates a robots.txt file in a subdirectory of the docs source


### PR DESCRIPTION
The goal of this is to reduce the likelihood of damaging the presence of the HoloViz sites on search engines by making sure they adopt some best practices wrt SEO.

So far, the extension performs these actions:

- Checks html_baseurl is set
- Creates a sitemap.xml file in the subdirectory `_nbsite_versioned` of the docs source
- Creates a robots.txt file in the subdirectory `_nbsite_versioned` of the docs source
- Creates a 404.html file in the subdirectory `_nbsite_versioned` of the docs source

These files are generated to be then automatically picked up by the Github action that deploys the site, pushing them to S3 (see https://github.com/holoviz-dev/holoviz_tasks/pull/44).

Finally, I've included a script that I've used to check the redirects on hvplot-test.holoviz.org were all working as I expected. It could serve as a base (some tested links are hvplot dependent at the moment) for testing other sites when they are versioned. This is mostly about testing the `redirect-docs` AWS Lambda Edge Function.