### PR TITLE
fix import

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -9,7 +9,7 @@ from functools import partial
 from urllib.parse import urlparse
 
 import requests
-import sphinx.util
+import sphinx.util.logging
 
 from PIL import Image
 


### PR DESCRIPTION
Seeing this in our logs:

![image](https://github.com/user-attachments/assets/18183307-f8a1-4544-b0d2-f70e0bf22565)
