### PR TITLE
fix:  `fix_links` not throwing exception in ThreadPool

### DIFF
--- a/nbsite/scripts/_fix_links.py
+++ b/nbsite/scripts/_fix_links.py
@@ -96,7 +96,7 @@ def cleanup_links(path, inspect_links=False):
 
     text = component_links(text, path)
     soup = BeautifulSoup(text, features="html.parser")
-    for a in soup.findAll('a'):
+    for a in soup.find_all('a'):
         href = a.get('href', '')
         if '.ipynb' in href and 'http' not in href:
  #           for k, v in LINK_REPLACEMENTS.items():
@@ -117,7 +117,8 @@ def cleanup_links(path, inspect_links=False):
 
         if inspect_links and 'http' in a['href']:
             print(a['href'])
-    for img in soup.findAll('img'):
+
+    for img in soup.find_all('img'):
         src = img.get('src', '')
         if 'http' not in src and 'assets' in src:
             try_path = os.path.join(os.path.dirname(path), src)
@@ -132,7 +133,8 @@ def cleanup_links(path, inspect_links=False):
         f.write(str(soup))
 
 def fix_links(build_dir, inspect_links=False):
-    files = Path(build_dir).rglob("*.html")
+    files = map(os.fspath, Path(build_dir).rglob("*.html"))
     with ThreadPoolExecutor() as executor:
         func = partial(cleanup_links, inspect_links=inspect_links)
-        executor.map(func, files)
+        # list to force execution and raise potential exception
+        list(executor.map(func, files))


### PR DESCRIPTION
Because we never ran the future of the threadpool, we never raised exceptions coming from `fix_links`.

When calling `list` and forcing execution, we encounter the following error, which is resolved by converting the `Path` object to a string. 

![image](https://github.com/user-attachments/assets/cd9c9c3e-66c2-43fa-8d8d-f07620c91e88)


Also updated to use new API for bs4 (`find_all`).