### PR TITLE
enh: handle anchor links

### DIFF
--- a/nbsite/scripts/_fix_links.py
+++ b/nbsite/scripts/_fix_links.py
@@ -107,13 +107,14 @@ def cleanup_links(path, inspect_links=False):
             try_path = os.path.join(os.path.dirname(path), a['href'])
             if not os.path.exists(try_path):
                 num_name = os.path.basename(try_path)
-                name = re.split(r"^\d+( |-|_)", num_name)[-1]
+                name = re.split(r"^#?\d+( |-|_)", num_name)[-1]
                 new_path = try_path.replace(num_name, name)
                 if os.path.exists(new_path):
                     a['href'] = os.path.relpath(new_path, os.path.dirname(path))
                 else:
                     also_tried = 'Also tried: {}'.format(name) if name != num_name else ''
-                    warnings.warn('Found missing link {} in: {}. {}'.format(a['href'], path, also_tried))
+                    msg = 'Found missing link {} in: {}. {}'.format(a['href'], path, also_tried)
+                    warnings.warn(msg)
 
         if inspect_links and 'http' in a['href']:
             print(a['href'])


### PR DESCRIPTION
I'm not entirely sure why this happens, but I think it relates to myst parsing and the order in which files are parsed:

![image](https://github.com/user-attachments/assets/97441db3-86ed-4014-85e0-67e17f839ec9)

Interactivity is not parsed because it is run before Introduction, but Pipeline works as expected. This is because files are converted in alphabetical order (after stripping leading numbers)

With this fix running locally, it seems to work:

![image](https://github.com/user-attachments/assets/31fce56c-1b18-4b7c-b314-842d90600857)
