### PR TITLE
Add root to robots.txt

### DIFF
--- a/nbsite/validate_versioned/__init__.py
+++ b/nbsite/validate_versioned/__init__.py
@@ -171,6 +171,7 @@ def build_robots(app, our_dir):
         f.write("# Generated automatically by nbsite\n")
         f.write("User-agent: *\n")
         f.write("Disallow: /\n")
+        f.write("Allow: /$\n")
         f.write("Allow: /en/docs/latest/\n")
         f.write(f"Sitemap: {sitemap_url}\n")
     logger.info(f"robots.txt written at {out_path}")


### PR DESCRIPTION
The robots.txt file we ship only allows `/en/docs/latest` and so excludes the root. This seems to make Google unhappy, see the lack of description.

<img width="1036" height="617" alt="image" src="https://github.com/user-attachments/assets/5485b631-a154-4075-b155-b3f276fce5bc" />
