### PR TITLE
Use gallery title mappings for item pages

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -353,6 +353,12 @@ def convert_notebook_to_md(filename, directive='{pyodide}'):
             md += f'\n{backticks}'
     return md
 
+def _gallery_item_title(name, content):
+    titles = content.get('titles', {})
+    if name in titles:
+        return titles[name]
+    return ' '.join([n[0].capitalize()+n[1:] for n in name.replace('_', ' ').split(' ')])
+
 def generate_pyodide_markdown(
     app, page, section, backend, filename, src_dir, dest_dir,
     img_extension, deployed_file, deployed, skip
@@ -366,13 +372,13 @@ def generate_pyodide_markdown(
     basename = os.path.basename(filename)
     md_path = os.path.join(dest_dir, basename[:-len(extension)].replace(' ', '_') + 'md')
     name = basename[:-(len(extension)+1)]
-    title = ' '.join([n[0].capitalize()+n[1:] for n in name.replace('_', ' ').split(' ')])
     ftype = 'notebook' if extension == 'ipynb' else 'script'
 
     # Unpack config
     gallery_conf = app.config.nbsite_gallery_conf
     examples_dir = gallery_conf['examples_dir']
     content = gallery_conf['galleries'][page]
+    title = _gallery_item_title(name, content)
 
     # Download link options
     host = gallery_conf['host']
@@ -447,13 +453,13 @@ def generate_item_rst(
     name = basename[:-(len(extension)+1)]
     rel_path = os.path.relpath(os.path.join(src_dir, basename), dest_dir)
     rst_path = os.path.join(dest_dir, basename[:-len(extension)].replace(' ', '_') + 'rst')
-    title = ' '.join([n[0].capitalize()+n[1:] for n in name.replace('_', ' ').split(' ')])
     ftype = 'notebook' if extension == 'ipynb' else 'script'
 
     # Unpack config
     gallery_conf = app.config.nbsite_gallery_conf
     examples_dir = gallery_conf['examples_dir']
     content = gallery_conf['galleries'][page]
+    title = _gallery_item_title(name, content)
     skip_execute = gallery_conf['skip_execute']
 
     # Download link options

--- a/nbsite/tests/test_gallery.py
+++ b/nbsite/tests/test_gallery.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from nbsite.gallery.gen import generate_item_rst, generate_pyodide_markdown
+
+
+def _gallery_app():
+    gallery_conf = {
+        'deployment_url': None,
+        'download_as': None,
+        'examples_dir': 'examples',
+        'galleries': {
+            'panes': {
+                'titles': {
+                    'Vega': 'Altair & Vega',
+                },
+            },
+        },
+        'github_org': 'holoviz',
+        'github_project': 'panel',
+        'github_ref': 'main',
+        'host': 'GitHub',
+        'iframe_spinner': '',
+        'jupyterlite_url': None,
+        'nblink': None,
+        'skip_execute': [],
+    }
+    return SimpleNamespace(config=SimpleNamespace(nbsite_gallery_conf=gallery_conf))
+
+
+def test_generate_pyodide_markdown_uses_gallery_title(tmp_path):
+    source = tmp_path / 'src'
+    dest = tmp_path / 'dest'
+    source.mkdir()
+    dest.mkdir()
+    filename = source / 'Vega.py'
+    filename.write_text('print("vega")\n')
+
+    generate_pyodide_markdown(
+        _gallery_app(), 'panes', None, None, str(filename), str(source), str(dest),
+        'png', str(filename), False, False,
+    )
+
+    assert (dest / 'Vega.md').read_text().startswith('# Altair & Vega\n\n')
+
+
+def test_generate_item_rst_uses_gallery_title(tmp_path):
+    source = tmp_path / 'src'
+    dest = tmp_path / 'dest'
+    source.mkdir()
+    dest.mkdir()
+    filename = source / 'Vega.py'
+    filename.write_text('print("vega")\n')
+
+    generate_item_rst(
+        _gallery_app(), 'panes', None, None, str(filename), str(source), str(dest),
+        'png', str(filename), False, False,
+    )
+
+    assert (dest / 'Vega.rst').read_text().startswith('Altair & Vega\n=============\n\n')


### PR DESCRIPTION
Closes #353.

## What changed
- Added shared title resolution for generated gallery item pages.
- `generate_pyodide_markdown` and `generate_item_rst` now use the gallery `titles` mapping before falling back to filename-derived titles.
- Added regression coverage for Markdown and RST item generation using the Panel-style `Vega` -> `Altair & Vega` title override.

## Why
Gallery cards already honor `nbsite_gallery_conf["galleries"][...]["titles"]`, but generated item page headings and sidebar entries were still derived only from filenames. This made Panel pages such as `Vega` render as `Vega` instead of `Altair & Vega`.

## Validation
- `.venv/bin/python -m pytest nbsite/tests/test_gallery.py -q`
- `.venv/bin/python -m pytest nbsite/tests/test_gallery.py nbsite/tests/test_util.py -q`
- `git diff --check`

## Limitations
I ran focused tests for the changed generator paths rather than the full site build.

## AI disclosure
This draft PR was prepared with assistance from OpenAI Codex/ChatGPT. The code, tests, validation commands, and PR text were AI-assisted and reviewed in the local checkout before submission.
