### PR TITLE
Patch script for panel docs

### DIFF
--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -73,6 +73,14 @@ _STRIP_TAGS_RE = re.compile(
     re.I,
 )
 
+# Meta-refresh used by Sphinx/MyST stub pages that only redirect to an index
+# fragment (e.g. Panel how-to section landings). Attribute order varies.
+_META_REFRESH_RE = re.compile(
+    r"http-equiv\s*=\s*[\"']refresh[\"'][^>]*\bcontent\s*=\s*[\"'][^\"']*url=\s*([^\"'\s#>]+)(?:#([^\"'\s]+))?"
+    r"|\bcontent\s*=\s*[\"'][^\"']*url=\s*([^\"'\s#>]+)(?:#([^\"'\s]+))?[\"'][^>]*http-equiv\s*=\s*[\"']refresh[\"']",
+    re.I | re.S,
+)
+
 
 def default_label(path: Path) -> str:
     return path.stem.replace("_", " ")
@@ -223,6 +231,133 @@ def _select_html_body(soup: BeautifulSoup):
     return soup
 
 
+def _extract_meta_refresh(text: str) -> tuple[str, str | None] | None:
+    """Return ``(url, fragment)`` from a meta-refresh redirect, if present."""
+    match = _META_REFRESH_RE.search(text)
+    if match is None:
+        return None
+    url = match.group(1) or match.group(3)
+    fragment = match.group(2) or match.group(4)
+    if not url:
+        return None
+    return url, fragment
+
+
+def _prepare_html_node(node) -> None:
+    """Strip chrome from a BeautifulSoup node before pandoc conversion."""
+    for tag in node.find_all(HTML_STRIP_TAGS):
+        tag.decompose()
+
+    for dt in node.select("dt.sig, dt.sig-object"):
+        for tag in dt.find_all("a", class_="headerlink"):
+            tag.decompose()
+        source = dt.find("a", string=lambda t: t and "source" in t.lower() if t else False)
+        if source is not None:
+            source.decompose()
+        for tag in dt.find_all(True):
+            tag.unwrap()
+
+    for dt in node.select("dl.field-list dt"):
+        strong, classifier = dt.find("strong"), dt.find("span", class_="classifier")
+        if strong is not None and classifier is not None:
+            strong.insert_after(" : ")
+            strong.unwrap()
+            classifier.unwrap()
+
+    # Header permalinks and empty anchors add noise in LLM markdown.
+    for tag in node.find_all("a", class_="headerlink"):
+        tag.decompose()
+
+
+def _html_node_to_temp_file(node) -> Path:
+    """Write a prepared HTML node to a temp file for pandoc."""
+    _prepare_html_node(node)
+    temp = tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".html",
+        delete=False,
+        encoding="utf-8",
+    )
+    temp.write(str(node))
+    temp.close()
+    return Path(temp.name)
+
+
+def _convert_html_to_markdown(
+    html_path: Path,
+    output_path: Path,
+    *,
+    fragment: str | None = None,
+    warning_context: str | None = None,
+) -> bool:
+    """Convert rendered HTML (or one ``id=fragment`` section) to markdown."""
+    html = html_path.read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+    if fragment:
+        node = soup.find(id=fragment)
+        if node is None:
+            print(
+                f"  Warning: redirect target #{fragment} not found in {html_path}"
+            )
+            return False
+    else:
+        node = _select_html_body(soup)
+
+    temp_path = _html_node_to_temp_file(node)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if not _run_command(
+            _pandoc_command("html", output_path, temp_path),
+            warning_context or str(html_path),
+        ):
+            return False
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    _sanitize_markdown_output(output_path, deepen_relative_links=True)
+    return True
+
+
+def _try_expand_redirect_markdown(
+    source_path: Path,
+    output_path: Path,
+    rendered_html_path: Path | None,
+) -> bool:
+    """Expand a meta-refresh stub page into the redirected section's content.
+
+    Panel how-to landings are thin MyST pages that only meta-refresh to
+    ``index.html#section``. Copying them yields nearly empty markdown. When
+    rendered HTML is available, pull the target section instead.
+    """
+    text = source_path.read_text(encoding="utf-8")
+    target = _extract_meta_refresh(text)
+    if target is None and rendered_html_path is not None and rendered_html_path.exists():
+        target = _extract_meta_refresh(rendered_html_path.read_text(encoding="utf-8"))
+    if target is None:
+        return False
+
+    url, fragment = target
+    if url.startswith(("http:", "https:", "#", "mailto:")):
+        return False
+
+    base_dir = (
+        rendered_html_path.parent
+        if rendered_html_path is not None
+        else source_path.parent
+    )
+    target_html = (base_dir / url).resolve()
+    if not target_html.is_file():
+        print(f"  Warning: redirect target missing for {source_path}: {target_html}")
+        return False
+
+    return _convert_html_to_markdown(
+        target_html,
+        output_path,
+        fragment=fragment,
+        warning_context=str(source_path),
+    )
+
+
 def _remove_html_wrappers(text: str) -> str:
     text = re.sub(
         r"<span\b[^>]*title=\"Extension loaded\.[^\"]*\"[^>]*>\u2139</span>",
@@ -367,68 +502,27 @@ def _sanitize_markdown_output(path: Path, deepen_relative_links: bool = False) -
     path.write_text(_normalize_markdown(text), encoding="utf-8")
 
 
-def _write_rendered_html(rendered_html_path: Path) -> Path | None:
-    """Extract the page body from rendered Sphinx HTML into a temp HTML file."""
-    html = rendered_html_path.read_text(encoding="utf-8")
-    soup = BeautifulSoup(html, "html.parser")
-    input_node = _select_html_body(soup)
-
-    for tag in input_node.find_all(HTML_STRIP_TAGS):
-        tag.decompose()
-
-    for dt in input_node.select("dt.sig, dt.sig-object"):
-        for tag in dt.find_all("a", class_="headerlink"):
-            tag.decompose()
-        source = dt.find("a", string=lambda t: t and "source" in t.lower() if t else False)
-        if source is not None:
-            source.decompose()
-        for tag in dt.find_all(True):
-            tag.unwrap()
-
-    for dt in input_node.select("dl.field-list dt"):
-        strong, classifier = dt.find("strong"), dt.find("span", class_="classifier")
-        if strong is not None and classifier is not None:
-            strong.insert_after(" : ")
-            strong.unwrap()
-            classifier.unwrap()
-
-    temp = tempfile.NamedTemporaryFile(
-        "w",
-        suffix=".html",
-        delete=False,
-        encoding="utf-8",
-    )
-    temp.write(str(input_node))
-    temp.close()
-    return Path(temp.name)
-
-
 def _convert_rst(
     rst_path: Path,
     output_path: Path,
     rendered_html_path: Path | None = None,
 ) -> bool:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    input_path = rst_path
-    input_format = "rst"
-    temp_path: Path | None = None
 
     if rendered_html_path is not None and rendered_html_path.exists():
-        temp_path = _write_rendered_html(rendered_html_path)
-        if temp_path is not None:
-            input_path = temp_path
-            input_format = "html"
-    try:
-        if not _run_command(
-            _pandoc_command(input_format, output_path, input_path),
-            str(rst_path),
-        ):
-            return False
-    finally:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
+        # Prefer the Sphinx-rendered page so directives/cards expand usefully.
+        return _convert_html_to_markdown(
+            rendered_html_path,
+            output_path,
+            warning_context=str(rst_path),
+        )
 
-    _sanitize_markdown_output(output_path, deepen_relative_links=(input_format == "html"))
+    if not _run_command(
+        _pandoc_command("rst", output_path, rst_path),
+        str(rst_path),
+    ):
+        return False
+    _sanitize_markdown_output(output_path)
     return True
 
 
@@ -460,6 +554,14 @@ def build_markdown_docs(
 
             if path.suffix == ".md" and source.copy_markdown:
                 destination.parent.mkdir(parents=True, exist_ok=True)
+                rendered_html_path = _rendered_html_for(source, rel)
+                # Expand meta-refresh stubs (e.g. how-to section landings that
+                # only point at index.html#section) into real section content.
+                if _try_expand_redirect_markdown(path, destination, rendered_html_path):
+                    md_rel = destination.relative_to(markdown_root)
+                    generated.append(md_rel)
+                    print(f"  Expanded redirect {md_rel}")
+                    continue
                 shutil.copy2(path, destination)
                 generated.append(destination.relative_to(markdown_root))
                 print(f"  Copied {destination.relative_to(markdown_root)}")
@@ -546,47 +648,147 @@ def _matches_prefix(path: Path, prefix: Path) -> bool:
 
 
 def _build_url_pattern_body(section: LlmsSection, section_paths: Sequence[Path]) -> list[str]:
+    """Build a compact URL-pattern inventory for an llms.txt section.
+
+    Instead of listing every page as a separate markdown link, this renders
+    a single URL pattern plus a grouped inventory of path components.
+
+    Path structure is detected once, then one of these modes is chosen:
+
+    - **dotted_api**: all stems look like ``pkg.mod.method`` (3+ dot parts)
+    - **category_example**: all paths are exactly ``category/example``
+    - **mixed**: mix of standalone names and ``category/example``
+    - **nested**: any path deeper than ``category/example``
+    - **fallback**: flat list of every page (single-component or unknown shape)
+    """
+
     def _rel(path: Path) -> str:
+        """Relative stem under the section prefix, used as the pattern fill-in."""
         try:
             return path.relative_to(section.path_prefix).with_suffix("").as_posix()
         except ValueError:
             return path.stem
 
-    rels = sorted(_rel(path) for path in section_paths)
-    slash_parts = [Path(rel).parts for rel in rels]
-    dot_parts = [rel.split(".") for rel in rels]
+    rels = sorted(_rel(p) for p in section_paths)
+    if not rels:
+        return []
 
-    if all(len(parts) == 2 for parts in slash_parts):
-        body = [
-            f"Page URL pattern: `{section.url_pattern}` where {{path}} = {{category}}/{{example}}"
-        ]
-        first_category, first_example = slash_parts[0]
-        body.append(
-            f"  e.g. `{section.url_pattern.format(path=f'{first_category}/{first_example}')}`"
+    # Two views of the same stems:
+    # - slash_parts: directory-style hierarchy (foo/bar/baz) e.g explanation/api/callbacks
+    # - dot_parts: dotted API names (pkg.mod.method) e.g hvplot.hvPlot.box
+    slash_parts = [tuple(Path(r).parts) for r in rels]
+    dot_parts = [tuple(r.split(".")) for r in rels]
+    depths = [len(p) for p in slash_parts]
+    min_depth, max_depth = min(depths), max(depths)
+
+    # Prefer dotted API when every stem is clearly module-like. Checked first
+    # so paths such as ``pkg.mod.fn`` are not treated as flat single segments.
+    if all(len(d) >= 3 for d in dot_parts):
+        return _pattern_dotted_api(section.url_pattern, rels, dot_parts)
+
+    # Exact two-level tree: gallery-style category/example pages.
+    if min_depth == 2 and max_depth == 2:
+        return _pattern_slash_tree(
+            section.url_pattern,
+            where="{path} = {category}/{example}",
+            rels=rels,
+            slash_parts=slash_parts,
+            nested_only=False,
         )
-        for category, entries in groupby(slash_parts, key=lambda parts: parts[0]):
-            body.append(f"  {category}: {', '.join(entry[1] for entry in entries)}")
-        return body
 
-    if all(len(parts) >= 3 for parts in dot_parts):
-        body = [
-            f"Page URL pattern: `{section.url_pattern}` where {{stem}} = {{module}}.{{method}}"
-        ]
-        first = dot_parts[0]
-        first_stem = ".".join(first[:-1])
-        body.append(f"  e.g. `{section.url_pattern.format(stem=f'{first_stem}.{first[-1]}')}`")
-        def _dot_stem(parts: list[str]) -> str:
-            return ".".join(parts[:-1])
+    # Standalone pages plus optional category/example children.
+    if min_depth == 1 and max_depth == 2:
+        return _pattern_slash_tree(
+            section.url_pattern,
+            where="{path} = {example} or {category}/{example}",
+            rels=rels,
+            slash_parts=slash_parts,
+            nested_only=True,
+        )
 
-        for stem, entries in groupby(dot_parts, key=_dot_stem):
-            body.append(f"  {stem}: {', '.join(entry[-1] for entry in entries)}")
-        return body
+    # Deeper trees: keep first segment as category, join the rest with '/'.
+    if max_depth > 2:
+        return _pattern_slash_tree(
+            section.url_pattern,
+            where="{path} = {example} or {category}/{...}/{example}",
+            rels=rels,
+            slash_parts=slash_parts,
+            nested_only=True,
+        )
 
-    pages = ", ".join(rels)
+    # Single-component paths (or anything else): list them all.
+    return _pattern_fallback(section.url_pattern, rels)
+
+
+def _pattern_header(url_pattern: str, where: str, example: str) -> list[str]:
+    """Shared pattern line + concrete example URL.
+
+    ``where`` is concatenated (not interpolated) so brace placeholders such as
+    ``{path}`` survive into the output instead of being treated as f-string fields.
+    Both ``path`` and ``stem`` are passed to ``format`` so either placeholder works.
+    """
     return [
-        f"Page URL pattern: `{section.url_pattern}`",
-        f"  e.g. `{section.url_pattern.format(stem=rels[0], path=rels[0])}`",
-        f"Available pages ({len(section_paths)}): {pages}",
+        f"Page URL pattern: `{url_pattern}` where " + where,
+        f"  e.g. `{url_pattern.format(path=example, stem=example)}`",
+    ]
+
+
+def _group_by_first(parts_list: Sequence[tuple[str, ...]]) -> list[str]:
+    """Group paths by their first segment; join the remainder with ``/``."""
+    lines: list[str] = []
+    # Input must already be sorted so groupby sees contiguous keys.
+    for category, entries in groupby(parts_list, key=lambda p: p[0]):
+        children = ("/".join(entry[1:]) for entry in entries)
+        lines.append(f"  {category}: {', '.join(children)}")
+    return lines
+
+
+def _pattern_dotted_api(
+    url_pattern: str,
+    rels: Sequence[str],
+    dot_parts: Sequence[tuple[str, ...]],
+) -> list[str]:
+    """Group dotted API stems as ``module...: method, method``."""
+    body = _pattern_header(url_pattern, "{stem} = {module}.{method}", rels[0])
+    for stem, entries in groupby(dot_parts, key=lambda d: ".".join(d[:-1])):
+        body.append(f"  {stem}: {', '.join(e[-1] for e in entries)}")
+    return body
+
+
+def _pattern_slash_tree(
+    url_pattern: str,
+    where: str,
+    rels: Sequence[str],
+    slash_parts: Sequence[tuple[str, ...]],
+    *,
+    nested_only: bool,
+) -> list[str]:
+    """Render slash-hierarchy inventories, optionally with a standalone row.
+
+    When ``nested_only`` is True, single-segment paths are listed under
+    ``standalone:`` (not a URL category — just pages with no subdirectory)
+    and only multi-segment paths are grouped by category. When False, every
+    path is assumed multi-segment and grouped directly.
+    """
+    body = _pattern_header(url_pattern, where, rels[0])
+    if nested_only:
+        # Label deliberately avoids looking like a path category name.
+        standalone = [r for r, p in zip(rels, slash_parts) if len(p) == 1]
+        if standalone:
+            body.append(f"  standalone: {', '.join(standalone)}")
+        to_group = [p for p in slash_parts if len(p) >= 2]
+    else:
+        to_group = list(slash_parts)
+    body.extend(_group_by_first(to_group))
+    return body
+
+
+def _pattern_fallback(url_pattern: str, rels: Sequence[str]) -> list[str]:
+    """Last resort: pattern line plus a full comma-separated page list."""
+    return [
+        f"Page URL pattern: `{url_pattern}`",
+        f"  e.g. `{url_pattern.format(stem=rels[0], path=rels[0])}`",
+        f"Available pages ({len(rels)}): {', '.join(rels)}",
     ]
 
 

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -328,11 +328,18 @@ def _try_expand_redirect_markdown(
     Panel how-to landings are thin MyST pages that only meta-refresh to
     ``index.html#section``. Copying them yields nearly empty markdown. When
     rendered HTML is available, pull the target section instead.
+
+    Without rendered HTML there is nowhere to resolve the redirect target
+    from, so this is a no-op rather than emitting a spurious warning for
+    every stub page in projects that don't set ``rendered_source_dir``.
     """
+    if rendered_html_path is None or not rendered_html_path.exists():
+        return False
+
     text = source_path.read_text(encoding="utf-8")
-    target = _extract_meta_refresh(text)
-    if target is None and rendered_html_path is not None and rendered_html_path.exists():
-        target = _extract_meta_refresh(rendered_html_path.read_text(encoding="utf-8"))
+    target = _extract_meta_refresh(text) or _extract_meta_refresh(
+        rendered_html_path.read_text(encoding="utf-8")
+    )
     if target is None:
         return False
 
@@ -340,12 +347,7 @@ def _try_expand_redirect_markdown(
     if url.startswith(("http:", "https:", "#", "mailto:")):
         return False
 
-    base_dir = (
-        rendered_html_path.parent
-        if rendered_html_path is not None
-        else source_path.parent
-    )
-    target_html = (base_dir / url).resolve()
+    target_html = (rendered_html_path.parent / url).resolve()
     if not target_html.is_file():
         print(f"  Warning: redirect target missing for {source_path}: {target_html}")
         return False

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -167,14 +167,17 @@ class LlmsBuildConfig:
 
 def _iter_source_files(source: MarkdownSource) -> Iterable[Path]:
     """Yield source files, preferring .ipynb over .rst when both exist."""
-    # Collect all included paths grouped by stem.
-    stem_to_paths: dict[str, list[Path]] = {}
+    # Collect all included paths grouped by their directory + stem (not just
+    # stem) so that e.g. how_to/callbacks/index.md and how_to/state/index.md
+    # are treated as distinct pages instead of colliding on "index".
+    stem_to_paths: dict[Path, list[Path]] = {}
     for path in sorted(source.source_dir.rglob("*")):
         if not path.is_file():
             continue
         rel_path = path.relative_to(source.source_dir)
         if _is_included(rel_path, source.include_suffixes, source.exclude_dir_names, source.exclude_files):
-            stem_to_paths.setdefault(path.stem, []).append(path)
+            key = rel_path.with_suffix("")
+            stem_to_paths.setdefault(key, []).append(path)
 
     # For each stem, emit the preferred file: .ipynb beats .rst; otherwise
     # preserve the sorted order.

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -436,6 +436,10 @@ def _strip_markdown_noise(text: str) -> str:
     # Remove {eval-rst} code blocks
     text = re.sub(r"```\{eval-rst\}\n.*?\n```", "", text, flags=re.S)
 
+    # MyST pyodide fences are executable docs chrome; keep the code as plain python.
+    # Handles both `{pyodide}` and the occasional doubled-brace `{{pyodide}`.
+    text = re.sub(r"^```\{\{?pyodide\}?\s*$", "```python", text, flags=re.M)
+
     # Remove MySTMarkdown targets like (option-name)=
     text = re.sub(r"^\([a-zA-Z_-]+\)=$", "", text, flags=re.M)
 
@@ -453,6 +457,16 @@ def _strip_markdown_noise(text: str) -> str:
 
     text = re.sub(r"\s*\[#\]\(#[^)]*\)", "", text)
     text = re.sub(r"\[source\]\([^)]*\)", "", text)
+
+    # Remove Jupyterlite / GitHub download banners (optionally followed by ---).
+    text = re.sub(
+        r"^\s*\[Open this notebook in Jupyterlite\]\([^)]*\)"
+        r"(?:\s*\|\s*\[Download this notebook from GitHub[^\]]*\]\([^)]*\))?"
+        r"\s*(?:\n+\s*---\s*)?\n?",
+        "",
+        text,
+        flags=re.M | re.I,
+    )
 
     # Remove the Jupyter-notebook banner (with or without the "On this page" preamble)
     # and the trailing "Edit on GitHub / Show Source" links that always follow it.
@@ -568,6 +582,9 @@ def build_markdown_docs(
                     print(f"  Expanded redirect {md_rel}")
                     continue
                 shutil.copy2(path, destination)
+                # Always sanitize copied markdown so MyST chrome (pyodide
+                # fences, Jupyterlite banners, etc.) is stripped consistently.
+                _sanitize_markdown_output(destination)
                 generated.append(destination.relative_to(markdown_root))
                 print(f"  Copied {destination.relative_to(markdown_root)}")
                 continue

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -437,8 +437,9 @@ def _strip_markdown_noise(text: str) -> str:
     text = re.sub(r"```\{eval-rst\}\n.*?\n```", "", text, flags=re.S)
 
     # MyST pyodide fences are executable docs chrome; keep the code as plain python.
-    # Handles both `{pyodide}` and the occasional doubled-brace `{{pyodide}`.
-    text = re.sub(r"^```\{\{?pyodide\}?\s*$", "```python", text, flags=re.M)
+    # Handles `{pyodide}`, the doubled-brace `{{pyodide}`, and any backtick
+    # count (3+), so fences nested with 4 backticks are normalized too.
+    text = re.sub(r"^(`{3,})\{\{?pyodide\}?\s*$", r"\1python", text, flags=re.M)
 
     # Remove MySTMarkdown targets like (option-name)=
     text = re.sub(r"^\([a-zA-Z_-]+\)=$", "", text, flags=re.M)

--- a/nbsite/tests/test_build_llms_txt.py
+++ b/nbsite/tests/test_build_llms_txt.py
@@ -3,9 +3,9 @@ from pathlib import Path
 import pytest
 
 from nbsite.scripts._build_llms_txt import (
-    LlmsBuildConfig, LlmsSection, MarkdownSource, _convert_notebook,
-    _deepen_relative_links, _normalize_markdown, _strip_markdown_noise,
-    build_markdown_docs, generate_llms_txt,
+    LlmsBuildConfig, LlmsSection, MarkdownSource, _build_url_pattern_body,
+    _convert_notebook, _deepen_relative_links, _normalize_markdown,
+    _strip_markdown_noise, build_markdown_docs, generate_llms_txt,
 )
 
 
@@ -220,3 +220,91 @@ def test_convert_notebook_handles_non_notebook(tmp_path):
     text_file.write_text("Just some text")
     result = _convert_notebook(text_file)
     assert result is None
+
+
+def test_build_markdown_docs_expands_meta_refresh_redirects(tmp_path):
+    """Stub pages that meta-refresh to index#section should expand that section."""
+    source_dir = tmp_path / "doc" / "how_to"
+    source_dir.mkdir(parents=True)
+    built = tmp_path / "builtdocs" / "how_to"
+    built.mkdir(parents=True)
+    output_dir = tmp_path / "builtdocs" / "markdown"
+
+    stub = source_dir / "build_apps.md"
+    stub.write_text(
+        ".. raw:: html\n"
+        "    <head>\n"
+        "        <meta http-equiv='refresh' content='0; URL=./index.html#build-apps'>\n"
+        "    </head>\n\n"
+        "# Build apps\n"
+    )
+    # Rendered landing page (unused for expansion target, but present like Sphinx output).
+    (built / "build_apps.html").write_text(
+        "<html><head>"
+        "<meta http-equiv='refresh' content='0; URL=./index.html#build-apps'>"
+        "</head><body><main id='main-content'><p>stub</p></main></body></html>"
+    )
+    (built / "index.html").write_text(
+        "<html><body><main id='main-content'>"
+        "<section id='build-apps'>"
+        "<h2>Build apps</h2>"
+        "<p>How to construct components.</p>"
+        "<a href='components/index.html'>Create Components</a>"
+        "</section>"
+        "<section id='other'><h2>Other</h2><p>Ignore me.</p></section>"
+        "</main></body></html>"
+    )
+
+    generated = build_markdown_docs(
+        (
+            MarkdownSource(
+                source_dir=tmp_path / "doc",
+                output_dir=output_dir,
+                rendered_source_dir=tmp_path / "builtdocs",
+            ),
+        ),
+        output_dir,
+    )
+
+    assert Path("how_to/build_apps.md") in generated
+    text = (output_dir / "how_to" / "build_apps.md").read_text()
+    assert "How to construct components." in text
+    assert "Create Components" in text
+    assert "Ignore me." not in text
+    assert "meta" not in text.lower()
+    assert "http-equiv" not in text.lower()
+
+
+def test_build_url_pattern_body_mixed_depth_groups_by_category():
+    section = LlmsSection(
+        title="how-to",
+        description="How-to guides.",
+        path_prefix=Path("how_to"),
+        url_pattern="/markdown/how_to/{path}.md",
+    )
+    paths = [
+        Path("how_to/build_apps.md"),
+        Path("how_to/authentication/access_tokens.md"),
+        Path("how_to/callbacks/examples/streaming_bokeh.md"),
+        Path("how_to/callbacks/async.md"),
+    ]
+    body = _build_url_pattern_body(section, paths)
+    text = "\n".join(body)
+    assert "standalone: build_apps" in text
+    assert "authentication: access_tokens" in text
+    assert "callbacks: async, examples/streaming_bokeh" in text
+
+
+def test_build_url_pattern_body_uniform_two_parts_uses_clean_format():
+    section = LlmsSection(
+        title="reference",
+        description="Reference.",
+        path_prefix=Path("reference"),
+        url_pattern="/markdown/reference/{path}.md",
+    )
+    paths = [Path("reference/widgets/Button.md"), Path("reference/panes/HTML.md")]
+    body = _build_url_pattern_body(section, paths)
+    text = "\n".join(body)
+    assert "{path} = {category}/{example}" in text
+    assert "widgets: Button" in text
+    assert "panes: HTML" in text

--- a/nbsite/tests/test_build_llms_txt.py
+++ b/nbsite/tests/test_build_llms_txt.py
@@ -59,6 +59,26 @@ def test_build_markdown_docs_converts_rst_to_md(tmp_path):
     assert "This is an example." in output_text
 
 
+def test_build_markdown_docs_keeps_index_files_per_directory(tmp_path):
+    """index.md files in different directories must not collide on stem."""
+    source_dir = tmp_path / "doc"
+    output_dir = tmp_path / "builtdocs" / "markdown"
+    for name in ("callbacks", "state"):
+        page_dir = source_dir / "how_to" / name
+        page_dir.mkdir(parents=True)
+        (page_dir / "index.md").write_text(f"# {name} index\n")
+
+    generated = build_markdown_docs(
+        (MarkdownSource(source_dir=source_dir, output_dir=output_dir),),
+        output_dir,
+    )
+
+    assert Path("how_to/callbacks/index.md") in generated
+    assert Path("how_to/state/index.md") in generated
+    assert "callbacks index" in (output_dir / "how_to" / "callbacks" / "index.md").read_text()
+    assert "state index" in (output_dir / "how_to" / "state" / "index.md").read_text()
+
+
 def test_build_markdown_docs_output_dir_outside_markdown_root(tmp_path):
     source_dir = tmp_path / "doc"
     source_dir.mkdir()

--- a/nbsite/tests/test_build_llms_txt.py
+++ b/nbsite/tests/test_build_llms_txt.py
@@ -203,6 +203,54 @@ def test_strip_markdown_noise_unescapes_python_kwargs_asterisks():
     assert r"\*\*" not in cleaned
 
 
+def test_strip_markdown_noise_normalizes_pyodide_fences():
+    text = "# Title\n\n```{pyodide}\nimport panel as pn\n```\n\n```{{pyodide}\nx = 1\n```\n"
+    cleaned = _strip_markdown_noise(text)
+    assert "```python\nimport panel as pn\n```" in cleaned
+    assert "```python\nx = 1\n```" in cleaned
+    assert "{pyodide}" not in cleaned
+
+
+def test_strip_markdown_noise_removes_jupyterlite_banner():
+    text = (
+        "# HoloViews\n\n"
+        "[Open this notebook in Jupyterlite](https://panelite.holoviz.org/lab?path=/x.ipynb) | "
+        "[Download this notebook from GitHub (right-click to download).]"
+        "(https://raw.githubusercontent.com/holoviz/panel/main/examples/x.ipynb)\n\n"
+        "---\n\n"
+        "Body text.\n\n"
+        "[Open this notebook in Jupyterlite](https://panelite.holoviz.org/lab?path=/x.ipynb) | "
+        "[Download this notebook from GitHub (right-click to download).]"
+        "(https://raw.githubusercontent.com/holoviz/panel/main/examples/x.ipynb)\n"
+    )
+    cleaned = _strip_markdown_noise(text)
+    assert "Jupyterlite" not in cleaned
+    assert "Download this notebook" not in cleaned
+    assert "Body text." in cleaned
+    assert cleaned.startswith("# HoloViews\n")
+
+
+def test_build_markdown_docs_sanitizes_copied_markdown(tmp_path):
+    source_dir = tmp_path / "doc"
+    source_dir.mkdir()
+    output_dir = tmp_path / "builtdocs" / "markdown"
+    (source_dir / "guide.md").write_text(
+        "# Guide\n\n"
+        "[Open this notebook in Jupyterlite](https://example.com/lab)\n\n"
+        "```{pyodide}\nprint(1)\n```\n"
+    )
+
+    build_markdown_docs(
+        (MarkdownSource(source_dir=source_dir, output_dir=output_dir),),
+        output_dir,
+    )
+
+    text = (output_dir / "guide.md").read_text()
+    assert "Jupyterlite" not in text
+    assert "```python\nprint(1)\n```" in text
+    assert "{pyodide}" not in text
+
+
 def test_deepen_relative_links_only_deepens_shared_assets():
     text = (
         "![bar](../_images/simple_area.png)\n\n"


### PR DESCRIPTION
This PR updates llms build script to accommodate some peculiar Panel docs patterns.

Changes:
- [x] **Expand meta-refresh redirect stubs into real content.** Some doc pages (e.g. Panel's how-to landings) only `<meta refresh>` to an index page anchor and produce nearly-empty markdown when copied as-is. `build_markdown_docs` now detects these and pulls the target section's content from the rendered HTML instead.
- [x] **Fix `_iter_source_files` dropping same-named files across directories.** Files were deduplicated by bare filename stem (e.g. "index"), so every `index.md/index.rst` in the whole source tree collided into one dict key and only one survived. This silently dropped 30+ index pages and broke links pointing at them (e.g. callbacks/index.md, state/index.md). Now deduplicated by relative path (directory + stem).
- [x] **Rename** top-level: → standalone: in `llms.txt` URL-pattern summaries so single-segment pages aren't misread as a URL category. This is a minor change to avoid confusing the LLMs
- [x] Refactored  `_build_url_pattern_body`. Output unchanged for all existing path shapes.
- [x] Refactor HTML→Markdown conversion into shared helpers (_prepare_html_node, _convert_html_to_markdown) reused by both the RST+rendered-HTML path and the new redirect-expansion path, removing duplicated logic.

- [x] Updated the tests to account for the changes.

N/B: hvPlot and HoloViews builds work same way. No regression.

AI Usage: Kilo code - Auto efficient.

### Result

[panel/builtdocs/markdown.zip](https://github.com/user-attachments/files/30981782/markdown.zip)

[panel/builtdocs/llms.txt](https://github.com/user-attachments/files/30981790/llms.txt)
