### PR TITLE
docs: fix build warnings

### DIFF
--- a/nbsite/scripts/_fix_links.py
+++ b/nbsite/scripts/_fix_links.py
@@ -116,6 +116,12 @@ def cleanup_links(path, inspect_links=False):
                     msg = 'Found missing link {} in: {}. {}'.format(a['href'], path, also_tried)
                     warnings.warn(msg)
 
+        # Append index.html to relative links that end in / (directory links)
+        # so the final HTML resolves to the index page (e.g. ../user_guide/
+        # -> ../user_guide/index.html).
+        elif href.endswith('/') and 'http' not in href:
+            a['href'] = href + 'index.html'
+
         if inspect_links and 'http' in a['href']:
             print(a['href'])
 

--- a/nbsite/scripts/_fix_links.py
+++ b/nbsite/scripts/_fix_links.py
@@ -116,9 +116,6 @@ def cleanup_links(path, inspect_links=False):
                     msg = 'Found missing link {} in: {}. {}'.format(a['href'], path, also_tried)
                     warnings.warn(msg)
 
-        # Append index.html to relative links that end in / (directory links)
-        # so the final HTML resolves to the index page (e.g. ../user_guide/
-        # -> ../user_guide/index.html).
         elif href.endswith('/') and 'http' not in href:
             a['href'] = href + 'index.html'
 

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -127,15 +127,6 @@ html_last_updated_fmt = '%Y-%m-%d'
 
 rediraffe_redirects = {}
 
-# Link str/type to the stdlib docs instead of matching same-named project
-# objects (e.g. HoloViews' Dimension.str), which would trigger warnings.
-numpydoc_xref_param_type = True
-numpydoc_xref_type = True
-numpydoc_xref_aliases = {
-    "str": "builtins.str",
-    "type": "builtins.type",
-}
-
 suppress_warnings = [
     # Ignore: (WARNING/2) Document headings start at H2, not H1
     "myst.header",

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -127,6 +127,8 @@ html_last_updated_fmt = '%Y-%m-%d'
 
 rediraffe_redirects = {}
 
+# Link str/type to the stdlib docs instead of matching same-named project
+# objects (e.g. HoloViews' Dimension.str), which would trigger warnings.
 numpydoc_xref_param_type = True
 numpydoc_xref_type = True
 numpydoc_xref_aliases = {
@@ -311,6 +313,10 @@ def strip_html_from_links(app, docname, source):
     "reference target not found" warnings. Removing the extension lets Sphinx
     resolve the link as an internal document. Absolute URLs (containing ``://``)
     are left untouched.
+
+    This is a ``source-read`` hook and must run before parsing, so it lives
+    here rather than in ``scripts/_fix_links.py``, which post-processes
+    the built HTML instead.
     """
     path = os.fspath(app.env.doc2path(docname))
     if not path.endswith((".md", ".markdown", ".mdown", ".mkd")):

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -277,7 +277,7 @@ def add_hv_sidebar_dropdown_context(app, pagename, templatename, context, doctre
     context['hv_sidebar_dropdown'] = app.config.nbsite_hv_sidebar_dropdown
 
 
-def mpltype_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+def _mpltype_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Render matplotlib type roles (e.g. ``:mpltype:`color```) as literals.
 
     The matplotlib extension (:mod:`matplotlib.sphinxext`) registers this role
@@ -296,7 +296,7 @@ def mpltype_role(name, rawtext, text, lineno, inliner, options=None, content=Non
 _HTML_MD_LINK_RE = re.compile(r"\b([\w./:+-]+\.html)\b")
 
 
-def strip_html_from_links(app, docname, source):
+def _strip_html_from_links_in_markdown(app, docname, source):
     """Strip ``.html`` from relative links in markdown source files.
 
     Sphinx/MyST treat relative links with an ``.html`` extension as external
@@ -332,10 +332,10 @@ def setup(app):
 
     nbbuild.setup(app)
     app.connect("builder-inited", remove_mystnb_static)
-    app.connect("source-read", strip_html_from_links)
+    app.connect("source-read", _strip_html_from_links_in_markdown)
 
     if find_spec("matplotlib"):
-        app.add_role("mpltype", mpltype_role)
+        app.add_role("mpltype", _mpltype_role)
 
     # hv_sidebar_dropdown
     app.add_config_value('nbsite_hv_sidebar_dropdown', {}, 'html')

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -9,6 +9,8 @@ import re
 import subprocess
 import sys
 
+from importlib.util import find_spec
+
 import nbsite as _nbsite
 
 from nbsite import nbbuild
@@ -310,7 +312,7 @@ def strip_html_from_links(app, docname, source):
     resolve the link as an internal document. Absolute URLs (containing ``://``)
     are left untouched.
     """
-    path = app.env.doc2path(docname)
+    path = os.fspath(app.env.doc2path(docname))
     if not path.endswith((".md", ".markdown", ".mdown", ".mkd")):
         return
 
@@ -335,8 +337,8 @@ def setup(app):
     app.connect("builder-inited", remove_mystnb_static)
     app.connect("source-read", strip_html_from_links)
 
-    # Avoid broken links/warnings for :mpltype:`...` roles (see mpltype_role).
-    app.add_role("mpltype", mpltype_role)
+    if find_spec("matplotlib"):
+        app.add_role("mpltype", mpltype_role)
 
     # hv_sidebar_dropdown
     app.add_config_value('nbsite_hv_sidebar_dropdown', {}, 'html')

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 import os
 import pathlib as _pathlib
+import re
 import subprocess
 import sys
 
@@ -123,6 +124,13 @@ copyright_fmt = "{start_year}-{current_year} Holoviz contributors"
 html_last_updated_fmt = '%Y-%m-%d'
 
 rediraffe_redirects = {}
+
+numpydoc_xref_param_type = True
+numpydoc_xref_type = True
+numpydoc_xref_aliases = {
+    "str": "builtins.str",
+    "type": "builtins.type",
+}
 
 suppress_warnings = [
     # Ignore: (WARNING/2) Document headings start at H2, not H1
@@ -274,6 +282,47 @@ def add_hv_sidebar_dropdown_context(app, pagename, templatename, context, doctre
     context['hv_sidebar_dropdown'] = app.config.nbsite_hv_sidebar_dropdown
 
 
+def mpltype_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """Render matplotlib type roles (e.g. ``:mpltype:`color```) as literals.
+
+    The matplotlib extension (:mod:`matplotlib.sphinxext`) registers this role
+    to link to matplotlib's own reference pages, but those targets do not exist
+    in projects that do not document matplotlib types against its intersphinx
+    inventory. Rendering the type name as a literal avoids broken links and
+    warnings.
+    """
+    from docutils import nodes
+
+    return [nodes.literal(rawtext, text, classes=["docutils"])], []
+
+
+# Matches an .html-relative link target (e.g. user_guide/Annotating_Data.html,
+# ../gallery/index.html, Annotating_Data.html).
+_HTML_MD_LINK_RE = re.compile(r"\b([\w./:+-]+\.html)\b")
+
+
+def strip_html_from_links(app, docname, source):
+    """Strip ``.html`` from relative links in markdown source files.
+
+    Sphinx/MyST treat relative links with an ``.html`` extension as external
+    URLs rather than internal document references, which triggers
+    "reference target not found" warnings. Removing the extension lets Sphinx
+    resolve the link as an internal document. Absolute URLs (containing ``://``)
+    are left untouched.
+    """
+    path = app.env.doc2path(docname)
+    if not path.endswith((".md", ".markdown", ".mdown", ".mkd")):
+        return
+
+    def _replace(match):
+        url = match.group(0)
+        if "://" in url:
+            return url
+        return url[:-len(".html")]
+
+    source[0] = _HTML_MD_LINK_RE.sub(_replace, source[0])
+
+
 def setup(app):
     try:
         from nbsite.paramdoc import param_formatter, param_skip
@@ -284,6 +333,10 @@ def setup(app):
 
     nbbuild.setup(app)
     app.connect("builder-inited", remove_mystnb_static)
+    app.connect("source-read", strip_html_from_links)
+
+    # Avoid broken links/warnings for :mpltype:`...` roles (see mpltype_role).
+    app.add_role("mpltype", mpltype_role)
 
     # hv_sidebar_dropdown
     app.add_config_value('nbsite_hv_sidebar_dropdown', {}, 'html')


### PR DESCRIPTION
This PR makes a few small fixes and defaults for downstream projects that  addresses doc build warnings around relative `.html` links and `.md` source files, broken `:mpltype:` roles, and missing `numpydoc` cross-reference aliases. See https://github.com/holoviz/holoviews/pull/6985

## Changes
- [x] Add `numpydoc_xref_param_type`, `numpydoc_xref_type`, and `numpydoc_xref_aliases` for str/type
- [x] Register `mpltype` role that renders `:mpltype:` as a literal. Matplotlib's sphinx extension registers this role to link to its own reference pages, but those targets don't exist in projects that don't document matplotlib types against intersphinx.
- [x] Add a hook (`strip_html_from_links`) that strips `.html` from relative links in `.md` source files before Sphinx parses them. Sphinx/MyST treat `.html`-suffixed relative links as external URLs, causing "reference target not found" warnings. 
- [x] Append `index.html` to relative links ending in `/` during HTML post-processing (e.g. `../user_guide/` -> `../user_guide/index.html`).