### PR TITLE
fix: strip nbsite ordering prefixes from llms.txt markdown paths

### DIFF
--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -366,6 +366,7 @@ def _path_and_order(filepath, keep_numbers):
     num_name = os.path.basename(filepath)
     leading_num = re.match(r"^\d+", num_name)
     if not keep_numbers:
+        # Keep in sync with nbsite/scripts/_build_llms_txt.py::_strip_numeric_prefix.
         name = re.split(r"^\d+( |-|_)", num_name)[-1]
         filepath = filepath.replace(num_name, name)
     return filepath, int(leading_num.group(0)) if leading_num else None

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -13,7 +13,7 @@ import tempfile
 
 from dataclasses import dataclass, field
 from itertools import groupby
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
 from bs4 import BeautifulSoup
@@ -498,7 +498,7 @@ def _strip_markdown_noise(text: str) -> str:
         if url.startswith(("http:", "https:", "#", "mailto:")):
             return f"({url}{fragment})"
         stem = url.removesuffix('.html').removesuffix('.ipynb')
-        stem = _strip_numeric_prefix(PurePosixPath(stem)).as_posix()
+        stem = _strip_numeric_prefix(Path(stem)).as_posix()
         return f"({stem}.md{fragment})"
 
     text = re.sub(

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -81,7 +81,7 @@ _META_REFRESH_RE = re.compile(
     re.I | re.S,
 )
 
-
+# Should match its counterpart file name in the html docs, i.e Introduction.html -> Introduction.md.
 _NUM_PREFIX_RE = re.compile(r"^\d+[-_ ]")
 
 

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -13,7 +13,7 @@ import tempfile
 
 from dataclasses import dataclass, field
 from itertools import groupby
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Callable, Iterable, Sequence
 
 from bs4 import BeautifulSoup
@@ -80,6 +80,19 @@ _META_REFRESH_RE = re.compile(
     r"|\bcontent\s*=\s*[\"'][^\"']*url=\s*([^\"'\s#>]+)(?:#([^\"'\s]+))?[\"'][^>]*http-equiv\s*=\s*[\"']refresh[\"']",
     re.I | re.S,
 )
+
+
+_NUM_PREFIX_RE = re.compile(r"^\d+[-_ ]")
+
+
+def _strip_numeric_prefix(rel: Path) -> Path:
+    """Strip a leading ``<digits>-``/``_``/`` `` prefix from each path part.
+
+    Mirrors nbsite's ``cmd._path_and_order`` behavior for rst generation, so
+    e.g. ``1-Introduction.ipynb`` becomes ``Introduction.md`` in the markdown
+    output tree instead of keeping the ordering prefix in the visible name.
+    """
+    return Path(*(_NUM_PREFIX_RE.sub("", part) for part in rel.parts))
 
 
 def default_label(path: Path) -> str:
@@ -484,7 +497,9 @@ def _strip_markdown_noise(text: str) -> str:
         url, fragment = match.group(1), match.group(2) or ""
         if url.startswith(("http:", "https:", "#", "mailto:")):
             return f"({url}{fragment})"
-        return f"({url.removesuffix('.html').removesuffix('.ipynb')}.md{fragment})"
+        stem = url.removesuffix('.html').removesuffix('.ipynb')
+        stem = _strip_numeric_prefix(PurePosixPath(stem)).as_posix()
+        return f"({stem}.md{fragment})"
 
     text = re.sub(
         r"\((?!http|https|#|mailto)([^()]*\.(?:html|ipynb))(#[^)]*)?\)",
@@ -570,7 +585,7 @@ def build_markdown_docs(
     for source in sources:
         for path in _iter_source_files(source):
             rel = path.relative_to(source.source_dir)
-            destination = source.output_dir / rel
+            destination = source.output_dir / _strip_numeric_prefix(rel)
 
             if path.suffix == ".md" and source.copy_markdown:
                 destination.parent.mkdir(parents=True, exist_ok=True)

--- a/nbsite/scripts/_build_llms_txt.py
+++ b/nbsite/scripts/_build_llms_txt.py
@@ -81,7 +81,7 @@ _META_REFRESH_RE = re.compile(
     re.I | re.S,
 )
 
-# Should match its counterpart file name in the html docs, i.e Introduction.html -> Introduction.md.
+# Keep in sync with nbsite/cmd.py::_path_and_order.
 _NUM_PREFIX_RE = re.compile(r"^\d+[-_ ]")
 
 

--- a/nbsite/tests/test_build_llms_txt.py
+++ b/nbsite/tests/test_build_llms_txt.py
@@ -83,29 +83,19 @@ def test_build_markdown_docs_keeps_index_files_per_directory(tmp_path):
 @pytest.mark.parametrize(
     ("rel", "expected"),
     [
-        (Path("1-Introduction.ipynb"), Path("Introduction.ipynb")),
-        (Path("12_getting_started.md"), Path("getting_started.md")),
-        (Path("2 Overview.rst"), Path("Overview.rst")),
-        (Path("tutorials/1-Introduction.ipynb"), Path("tutorials/Introduction.ipynb")),
-        (Path("01-getting-started/1-Introduction.ipynb"), Path("getting-started/Introduction.ipynb")),
-        (Path("index.md"), Path("index.md")),
-        (Path("123.md"), Path("123.md")),
-        (Path("v2-api.md"), Path("v2-api.md")),
-    ],
-    ids=[
-        "hyphen_file",
-        "underscore_file",
-        "space_file",
-        "nested_file",
-        "prefix_on_each_part",
-        "no_prefix",
-        "digits_only_stem",
-        "non_leading_digits",
+        ("1-Introduction.ipynb", "Introduction.ipynb"),
+        ("12_getting_started.md", "getting_started.md"),
+        ("2 Overview.rst", "Overview.rst"),
+        ("tutorials/1-Introduction.ipynb", "tutorials/Introduction.ipynb"),
+        ("01-getting-started/1-Introduction.ipynb", "getting-started/Introduction.ipynb"),
+        ("index.md", "index.md"),
+        ("123.md", "123.md"),
+        ("v2-api.md", "v2-api.md"),
     ],
 )
 def test_strip_numeric_prefix(rel, expected):
     """Ordering prefixes must drop from every path part, matching rst generation."""
-    assert _strip_numeric_prefix(rel) == expected
+    assert _strip_numeric_prefix(Path(rel)) == Path(expected)
 
 
 def test_build_markdown_docs_strips_numeric_prefixes(tmp_path):
@@ -126,14 +116,9 @@ def test_build_markdown_docs_strips_numeric_prefixes(tmp_path):
         output_dir,
     )
 
-    assert Path("tutorials/Introduction.md") in generated
-    assert Path("Overview.md") in generated
-    assert Path("tutorials/1-Introduction.md") not in generated
-    assert Path("2-Overview.md") not in generated
-    assert (output_dir / "tutorials" / "Introduction.md").exists()
-    assert (output_dir / "Overview.md").exists()
-    assert not (output_dir / "tutorials" / "1-Introduction.md").exists()
-    assert not (output_dir / "2-Overview.md").exists()
+    expected = {Path("tutorials/Introduction.md"), Path("Overview.md")}
+    written = {p.relative_to(output_dir) for p in output_dir.rglob("*.md")}
+    assert set(generated) == written == expected
 
 
 def test_build_markdown_docs_output_dir_outside_markdown_root(tmp_path):
@@ -259,11 +244,12 @@ def test_strip_markdown_noise_strips_numeric_prefixes_in_links():
         "[Intro](1-Introduction.html#start)\n\n"
         "[Nested](../01-getting-started/2-Overview.ipynb)\n"
     )
+    expected = (
+        "[Intro](Introduction.md#start)\n\n"
+        "[Nested](../getting-started/Overview.md)\n"
+    )
     cleaned = _strip_markdown_noise(text)
-    assert "[Intro](Introduction.md#start)" in cleaned
-    assert "[Nested](../getting-started/Overview.md)" in cleaned
-    assert "1-Introduction" not in cleaned
-    assert "2-Overview" not in cleaned
+    assert cleaned == expected
 
 
 def test_strip_markdown_noise_unescapes_python_kwargs_asterisks():

--- a/nbsite/tests/test_build_llms_txt.py
+++ b/nbsite/tests/test_build_llms_txt.py
@@ -5,7 +5,8 @@ import pytest
 from nbsite.scripts._build_llms_txt import (
     LlmsBuildConfig, LlmsSection, MarkdownSource, _build_url_pattern_body,
     _convert_notebook, _deepen_relative_links, _normalize_markdown,
-    _strip_markdown_noise, build_markdown_docs, generate_llms_txt,
+    _strip_markdown_noise, _strip_numeric_prefix, build_markdown_docs,
+    generate_llms_txt,
 )
 
 
@@ -77,6 +78,62 @@ def test_build_markdown_docs_keeps_index_files_per_directory(tmp_path):
     assert Path("how_to/state/index.md") in generated
     assert "callbacks index" in (output_dir / "how_to" / "callbacks" / "index.md").read_text()
     assert "state index" in (output_dir / "how_to" / "state" / "index.md").read_text()
+
+
+@pytest.mark.parametrize(
+    ("rel", "expected"),
+    [
+        (Path("1-Introduction.ipynb"), Path("Introduction.ipynb")),
+        (Path("12_getting_started.md"), Path("getting_started.md")),
+        (Path("2 Overview.rst"), Path("Overview.rst")),
+        (Path("tutorials/1-Introduction.ipynb"), Path("tutorials/Introduction.ipynb")),
+        (Path("01-getting-started/1-Introduction.ipynb"), Path("getting-started/Introduction.ipynb")),
+        (Path("index.md"), Path("index.md")),
+        (Path("123.md"), Path("123.md")),
+        (Path("v2-api.md"), Path("v2-api.md")),
+    ],
+    ids=[
+        "hyphen_file",
+        "underscore_file",
+        "space_file",
+        "nested_file",
+        "prefix_on_each_part",
+        "no_prefix",
+        "digits_only_stem",
+        "non_leading_digits",
+    ],
+)
+def test_strip_numeric_prefix(rel, expected):
+    """Ordering prefixes must drop from every path part, matching rst generation."""
+    assert _strip_numeric_prefix(rel) == expected
+
+
+def test_build_markdown_docs_strips_numeric_prefixes(tmp_path):
+    """Output markdown paths must omit nbsite ordering prefixes."""
+    source_dir = tmp_path / "examples"
+    source_dir.mkdir()
+    output_dir = tmp_path / "builtdocs" / "markdown"
+    notebook = source_dir / "tutorials" / "1-Introduction.ipynb"
+    notebook.parent.mkdir(parents=True)
+    notebook.write_text(
+        '{"cells": [{"cell_type": "markdown", "source": ["# Introduction\\n"]}, '
+        '{"cell_type": "code", "source": [], "outputs": []}]}'
+    )
+    (source_dir / "2-Overview.md").write_text("# Overview\n")
+
+    generated = build_markdown_docs(
+        (MarkdownSource(source_dir=source_dir, output_dir=output_dir),),
+        output_dir,
+    )
+
+    assert Path("tutorials/Introduction.md") in generated
+    assert Path("Overview.md") in generated
+    assert Path("tutorials/1-Introduction.md") not in generated
+    assert Path("2-Overview.md") not in generated
+    assert (output_dir / "tutorials" / "Introduction.md").exists()
+    assert (output_dir / "Overview.md").exists()
+    assert not (output_dir / "tutorials" / "1-Introduction.md").exists()
+    assert not (output_dir / "2-Overview.md").exists()
 
 
 def test_build_markdown_docs_output_dir_outside_markdown_root(tmp_path):
@@ -194,6 +251,19 @@ def test_strip_markdown_noise_removes_html_conversion_artifacts():
     assert "Show Source" not in cleaned
     assert "[Home](../index.md)" in cleaned
     assert "../../ref/api/manual/hvplot.plotting.lag_plot.md" in cleaned
+
+
+def test_strip_markdown_noise_strips_numeric_prefixes_in_links():
+    """Relative html/ipynb links must drop ordering prefixes when rewritten to .md."""
+    text = (
+        "[Intro](1-Introduction.html#start)\n\n"
+        "[Nested](../01-getting-started/2-Overview.ipynb)\n"
+    )
+    cleaned = _strip_markdown_noise(text)
+    assert "[Intro](Introduction.md#start)" in cleaned
+    assert "[Nested](../getting-started/Overview.md)" in cleaned
+    assert "1-Introduction" not in cleaned
+    assert "2-Overview" not in cleaned
 
 
 def test_strip_markdown_noise_unescapes_python_kwargs_asterisks():


### PR DESCRIPTION
## Description

This PR strips leading numeric ordering prefixes from generated markdown filenames and rewritten relative links, matching `cmd._path_and_order`. 

Sites such as HoloViews name notebooks `1-Introduction.ipynb` so Sphinx can order the toctree, then drop that prefix in the published HTML. `build-llms` was keeping it, so `llms.txt` pointed at `1-Introduction.md` while intra-doc links still targeted `Introduction.html`.

I added `_strip_numeric_prefix` and applied it when writing the markdown output tree and when `_strip_markdown_noise` rewrites `.html/.ipynb` links to `.md`.
 
Manually tested it on the HoloViews docs locally:
**Before / After**
Before: `getting_started/1-Introduction.ipynb` became `/markdown/getting_started/1-Introduction.md`.
After: the same notebook is written as `/markdown/getting_started/Introduction.md`.

## AI Disclosure
Tool & Model: Kilo + kilo-auto/balanced
Usage: Applied the prefix-stripping patch and added unit tests.
- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist
- [x] Tests added and are passing